### PR TITLE
Add native UDP/multicast socket and Ethernet interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.direnv/
 /.pycache
 /.tox
+/.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,21 @@ This is an embedded systems project with a custom template library (FTL) and Pyt
 - Depends on ETL (Embedded Template Library) as external dependency
 - Custom `rip.py` script wraps common development tasks
 
+## Coding Style Guidance
+
+This project follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) with these specific modifications:
+
+### Naming Conventions
+- **Method names**: Use lowerCamelCase (e.g., `publishMessage()`, `getNodeId()`)
+- **Regular/standalone functions**: Use UpperCamelCase (e.g., `WriteU16LE()`, `ReadU32BE()`)
+- **Member variables**: Use snake_case (e.g., `node_id_`, `transfer_count_`)
+- **Accessors/mutators**: May be named like variables
+  - Example: `int count()` and `void set_count(int count)`
+
+### Comments
+- Use `//` for single-line comments instead of `/* */` style comments
+- Follow Google style guide recommendations for documentation comments
+
 ### Key Libraries
 
 - FTL provides abstractions for: buffers/memory pools, networking (IPv4/UDP), threading/mutex, singleton patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+
+- **Build debug**: `cmake --workflow --preset native-debug`
+- **Build release**: `cmake --workflow --preset native-release`
+- **Clean**: `rip -c` (deletes .bin folder and VS Code launch.json)
+- **Run tests**: `tox` (runs pytest and linting)
+- **Run single test**: Use ctest from build directory: `cd .bin/native-release/ && ctest`
+
+## Development Workflow
+
+- **Run application**: `rip -r native-debug:hello-world` (format: `<preset>:<target>`)
+- **Debug application**: `rip -d native-debug:hello-world`
+- **Python linting**: Uses flake8 and mypy via tox
+- **Setup environment**: Run `setup` script after clone
+
+## Architecture Overview
+
+This is an embedded systems project with a custom template library (FTL) and Python tooling:
+
+### Core Components
+
+- **FTL (Forge Template Library)**: Header-only C++17 library in `firmware/ftl/` providing embedded-specific utilities like memory pools, networking abstractions, and threading primitives
+- **Native Implementation**: Platform-specific implementations in `firmware/native/` for running on host systems
+- **ThreadX Support**: RTOS-specific implementations in `firmware/threadx/`
+- **Python Tooling**: Build and debug utilities in `scripts/package/forge/` including VS Code integration
+
+### Build System
+
+- Uses CMake with presets for native-debug and native-release configurations
+- Environment variables: `FORGE_ROOT`, `PROJECT_ROOT`, `ETL_ROOT` must be set
+- Depends on ETL (Embedded Template Library) as external dependency
+- Custom `rip.py` script wraps common development tasks
+
+### Key Libraries
+
+- FTL provides abstractions for: buffers/memory pools, networking (IPv4/UDP), threading/mutex, singleton patterns
+- Integrates with pw_unit_test framework for testing
+- Uses Jinja2 templates for code generation (CMSIS-SVD register definitions)
+
+## Testing Strategy
+
+- C++ unit tests in `test/native/` using custom unit test framework
+- Python tests in `test/pytest/` using pytest
+- Both accessed via `tox` command which runs pytest and linting

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Enable testing with ctest
 enable_testing()
 
+# Configure CTest to create Testing folder in the build directory
+set(CTEST_BINARY_DIRECTORY "${CMAKE_BINARY_DIR}")
+set(CTEST_OUTPUT_ON_FAILURE ON)
+
 # Make the platform module accessible from anywhere in the tree.
 list(APPEND CMAKE_MODULE_PATH ${PLATFORM_PATH})
 

--- a/README.md
+++ b/README.md
@@ -44,3 +44,9 @@ Tooling for forging embedded projects
 cd /.bin/native-release/
 ctest
 ```
+
+# Hello udp
+```
+cmake --workflow --preset native-debug && \
+rip -r native-debug:hello-udp
+```

--- a/firmware/ftl/include/ftl/byte_order.hpp
+++ b/firmware/ftl/include/ftl/byte_order.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <cstdint>
+
+namespace ftl {
+
+// Inline functions for efficient byte serialization with explicit endianness
+
+// Write uint16_t in little-endian format
+inline void WriteU16LE(uint8_t* dest, uint16_t value) {
+    dest[0] = static_cast<uint8_t>(value & 0xFF);
+    dest[1] = static_cast<uint8_t>((value >> 8) & 0xFF);
+}
+
+// Write uint16_t in big-endian format
+inline void WriteU16BE(uint8_t* dest, uint16_t value) {
+    dest[0] = static_cast<uint8_t>((value >> 8) & 0xFF);
+    dest[1] = static_cast<uint8_t>(value & 0xFF);
+}
+
+// Write uint32_t in little-endian format
+inline void WriteU32LE(uint8_t* dest, uint32_t value) {
+    dest[0] = static_cast<uint8_t>(value & 0xFF);
+    dest[1] = static_cast<uint8_t>((value >> 8) & 0xFF);
+    dest[2] = static_cast<uint8_t>((value >> 16) & 0xFF);
+    dest[3] = static_cast<uint8_t>((value >> 24) & 0xFF);
+}
+
+// Write uint32_t in big-endian format
+inline void WriteU32BE(uint8_t* dest, uint32_t value) {
+    dest[0] = static_cast<uint8_t>((value >> 24) & 0xFF);
+    dest[1] = static_cast<uint8_t>((value >> 16) & 0xFF);
+    dest[2] = static_cast<uint8_t>((value >> 8) & 0xFF);
+    dest[3] = static_cast<uint8_t>(value & 0xFF);
+}
+
+// Read uint16_t from little-endian format
+inline uint16_t ReadU16LE(const uint8_t* src) {
+    return static_cast<uint16_t>(src[0])
+         | (static_cast<uint16_t>(src[1]) << 8);
+}
+
+// Read uint16_t from big-endian format
+inline uint16_t ReadU16BE(const uint8_t* src) {
+    return (static_cast<uint16_t>(src[0]) << 8)
+         | static_cast<uint16_t>(src[1]);
+}
+
+// Read uint32_t from little-endian format
+inline uint32_t ReadU32LE(const uint8_t* src) {
+    return static_cast<uint32_t>(src[0])
+         | (static_cast<uint32_t>(src[1]) << 8)
+         | (static_cast<uint32_t>(src[2]) << 16)
+         | (static_cast<uint32_t>(src[3]) << 24);
+}
+
+// Read uint32_t from big-endian format
+inline uint32_t ReadU32BE(const uint8_t* src) {
+    return (static_cast<uint32_t>(src[0]) << 24)
+         | (static_cast<uint32_t>(src[1]) << 16)
+         | (static_cast<uint32_t>(src[2]) << 8)
+         | static_cast<uint32_t>(src[3]);
+}
+
+// Write uint64_t in little-endian format
+inline void WriteU64LE(uint8_t* dest, uint64_t value) {
+    dest[0] = static_cast<uint8_t>(value & 0xFF);
+    dest[1] = static_cast<uint8_t>((value >> 8) & 0xFF);
+    dest[2] = static_cast<uint8_t>((value >> 16) & 0xFF);
+    dest[3] = static_cast<uint8_t>((value >> 24) & 0xFF);
+    dest[4] = static_cast<uint8_t>((value >> 32) & 0xFF);
+    dest[5] = static_cast<uint8_t>((value >> 40) & 0xFF);
+    dest[6] = static_cast<uint8_t>((value >> 48) & 0xFF);
+    dest[7] = static_cast<uint8_t>((value >> 56) & 0xFF);
+}
+
+// Write uint64_t in big-endian format
+inline void WriteU64BE(uint8_t* dest, uint64_t value) {
+    dest[0] = static_cast<uint8_t>((value >> 56) & 0xFF);
+    dest[1] = static_cast<uint8_t>((value >> 48) & 0xFF);
+    dest[2] = static_cast<uint8_t>((value >> 40) & 0xFF);
+    dest[3] = static_cast<uint8_t>((value >> 32) & 0xFF);
+    dest[4] = static_cast<uint8_t>((value >> 24) & 0xFF);
+    dest[5] = static_cast<uint8_t>((value >> 16) & 0xFF);
+    dest[6] = static_cast<uint8_t>((value >> 8) & 0xFF);
+    dest[7] = static_cast<uint8_t>(value & 0xFF);
+}
+
+// Read uint64_t from little-endian format
+inline uint64_t ReadU64LE(const uint8_t* src) {
+    return static_cast<uint64_t>(src[0])
+         | (static_cast<uint64_t>(src[1]) << 8)
+         | (static_cast<uint64_t>(src[2]) << 16)
+         | (static_cast<uint64_t>(src[3]) << 24)
+         | (static_cast<uint64_t>(src[4]) << 32)
+         | (static_cast<uint64_t>(src[5]) << 40)
+         | (static_cast<uint64_t>(src[6]) << 48)
+         | (static_cast<uint64_t>(src[7]) << 56);
+}
+
+// Read uint64_t from big-endian format
+inline uint64_t ReadU64BE(const uint8_t* src) {
+    return (static_cast<uint64_t>(src[0]) << 56)
+         | (static_cast<uint64_t>(src[1]) << 48)
+         | (static_cast<uint64_t>(src[2]) << 40)
+         | (static_cast<uint64_t>(src[3]) << 32)
+         | (static_cast<uint64_t>(src[4]) << 24)
+         | (static_cast<uint64_t>(src[5]) << 16)
+         | (static_cast<uint64_t>(src[6]) << 8)
+         | static_cast<uint64_t>(src[7]);
+}
+
+}

--- a/firmware/ftl/include/ftl/deleter.hpp
+++ b/firmware/ftl/include/ftl/deleter.hpp
@@ -24,6 +24,19 @@ public:
   virtual void operator()(T* ptr) = 0;
 };
 
+
+// A default polymorphic deleter that just calls delete on the object.
+template <typename T>
+class DefaultDeleter final : public PolymorphicDeleter<T>
+{
+public:
+  void operator()(T* ptr) override
+  {
+    delete ptr;
+  }
+};
+
+
 // Delegating deleter that owns and forwards deletion to a PolymorphicDeleter<T> instance.
 // We store a pointer because PolymorphicDeleter<T> is abstract and cannot be used directly
 // as a std::unique_ptr deleter; owning the base-pointer enables runtime polymorphism and

--- a/firmware/ftl/include/ftl/deleter.hpp
+++ b/firmware/ftl/include/ftl/deleter.hpp
@@ -52,22 +52,25 @@ public:
     : polymorphic_deleter_{deleter}
   {}
 
+  // Default constructor, does nothing.
+  DelegatingDeleter() = default;
+
   // Default destructor.
   ~DelegatingDeleter() = default;
 
-  // Default copy and move constructors.
+  // Default copy and move.
   DelegatingDeleter(const DelegatingDeleter&) = default;
   DelegatingDeleter(DelegatingDeleter&&) noexcept = default;
-  
-  // Delete assignment operators.
-  DelegatingDeleter& operator=(const DelegatingDeleter&) = delete;  // Delete copy assignment operator
-  DelegatingDeleter& operator=(DelegatingDeleter&&) = delete;       // Delete move assignment operator
+  DelegatingDeleter& operator=(const DelegatingDeleter&) = default;
+  DelegatingDeleter& operator=(DelegatingDeleter&&) = default;
 
   // Call operator forwards deletion to the underlying polymorphic deleter.
   // @param ptr Pointer to object to delete.
   void operator()(T* ptr) const
   {
-    polymorphic_deleter_->operator()(ptr);
+    if (polymorphic_deleter_ != nullptr) {
+      polymorphic_deleter_->operator()(ptr);
+    }
   }
 
 private:

--- a/firmware/ftl/include/ftl/ethernet/interface.hpp
+++ b/firmware/ftl/include/ftl/ethernet/interface.hpp
@@ -13,7 +13,8 @@ class Interface
 {
   public:
 
-    Interface() = default;
+    Interface(ftl::ipv4::Address address, ftl::ipv4::Mask mask)
+      : address_{address}, mask_{mask} {}
     virtual ~Interface() = default;
 
     // No copying or moving.
@@ -23,6 +24,13 @@ class Interface
     Interface& operator=(Interface&&) = delete;      // Delete move assignment operator
 
     virtual ftl::ipv4::udp::SocketPtr CreateUdpSocket() = 0;
+
+    ftl::ipv4::Address address() const noexcept { return address_; }
+    ftl::ipv4::Mask mask() const noexcept { return mask_; }
+  
+  private:
+    ftl::ipv4::Address address_;
+    ftl::ipv4::Mask mask_;
 };
 
 }

--- a/firmware/ftl/include/ftl/ipv4/mask.hpp
+++ b/firmware/ftl/include/ftl/ipv4/mask.hpp
@@ -7,6 +7,7 @@ namespace ftl::ipv4 {
 
 class Mask : public Address {
   public:
+    using Address::Address;
     Mask (uint8_t m1, uint8_t m2, uint8_t m3, uint8_t m4)
       : Address(m1, m2, m3, m4)
     {

--- a/firmware/ftl/include/ftl/ipv4/udp/payload.hpp
+++ b/firmware/ftl/include/ftl/ipv4/udp/payload.hpp
@@ -10,24 +10,25 @@ namespace ftl::ipv4::udp {
 
 // Provides an interface to an ethernet data frame to access UDP payload data. 
 class Payload : private DataFrame {
-public:
+private:
   // Offsets into the raw frame
   //
   // NOTE: We have not implemented lower frame layers (e.g. EthernetFrame)
   static constexpr std::size_t kPayloadOffset = 0;
 
+public:
   // Construct with payload size
   explicit Payload(std::size_t size)
       : DataFrame(size)
   {}
   Payload() = default;
 
-  using DataFrame::size;
   using DataFrame::operator bool;
 
   // Access the UDP payload pointer
   uint8_t* data() noexcept { return front() + kPayloadOffset; }
   const uint8_t* data() const noexcept { return front() + kPayloadOffset; }
+  std::size_t size() const noexcept { return DataFrame::size() - kPayloadOffset; }
 
   // Returns the payload interpreted as characters in an etl::string_view
   etl::string_view string_view() const noexcept {

--- a/firmware/ftl/include/ftl/ipv4/udp/payload.hpp
+++ b/firmware/ftl/include/ftl/ipv4/udp/payload.hpp
@@ -25,14 +25,14 @@ public:
 
   using DataFrame::operator bool;
 
-  // Access the UDP payload pointer
-  uint8_t* data() noexcept { return front() + kPayloadOffset; }
-  const uint8_t* data() const noexcept { return front() + kPayloadOffset; }
+  // Access the UDP payload pointer - overrides DataFrame::front() with offset
+  uint8_t* front() noexcept { return DataFrame::front() + kPayloadOffset; }
+  const uint8_t* front() const noexcept { return DataFrame::front() + kPayloadOffset; }
   std::size_t size() const noexcept { return DataFrame::size() - kPayloadOffset; }
 
   // Returns the payload interpreted as characters in an etl::string_view
   etl::string_view string_view() const noexcept {
-    const char* data = reinterpret_cast<const char*>(this->data());
+    const char* data = reinterpret_cast<const char*>(this->front());
     return etl::string_view{ data, this->size() };
   }
 };

--- a/firmware/native/CMakeLists.txt
+++ b/firmware/native/CMakeLists.txt
@@ -9,12 +9,32 @@ target_sources(pw_unit_test
 )
 
 # Add FTL-native library.
-add_library(ftl-native INTERFACE)
-target_include_directories(ftl-native INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+add_library(ftl-native STATIC
+  native_udp_socket.cpp
+)
+target_link_libraries(ftl-native PUBLIC ftl)
+platformify(ftl-native)
 
-file(GLOB_RECURSE FTL_HEADERS CONFIGURE_DEPENDS
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/ftl/*.hpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/ftl/**/*.hpp
+target_include_directories(ftl-native
+  PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/include
 )
 
-target_sources(ftl INTERFACE ${FTL_HEADERS})
+# Expose headers for IDEs and consumers
+file(GLOB_RECURSE FTL_NATIVE_HEADERS
+  CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/ftl/*.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/ftl/**/*.hpp
+)
+
+target_sources(ftl-native
+  PUBLIC
+    ${FTL_NATIVE_HEADERS}
+)
+
+# TODO needed?
+# Link any platform dependencies (e.g. pthread on POSIX)
+target_link_libraries(ftl-native
+  PUBLIC
+    pthread
+)

--- a/firmware/native/CMakeLists.txt
+++ b/firmware/native/CMakeLists.txt
@@ -32,10 +32,3 @@ target_sources(ftl-native
   PUBLIC
     ${FTL_NATIVE_HEADERS}
 )
-
-# TODO needed?
-# Link any platform dependencies (e.g. pthread on POSIX)
-target_link_libraries(ftl-native
-  PUBLIC
-    pthread
-)

--- a/firmware/native/CMakeLists.txt
+++ b/firmware/native/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(pw_unit_test
 # Add FTL-native library.
 add_library(ftl-native STATIC
   native_udp_socket.cpp
+  native_ethernet_interface.cpp
 )
 target_link_libraries(ftl-native PUBLIC ftl)
 platformify(ftl-native)

--- a/firmware/native/include/ftl/native_ethernet_interface.hpp
+++ b/firmware/native/include/ftl/native_ethernet_interface.hpp
@@ -1,0 +1,18 @@
+// include/ftl/native_ethernet_interface.hpp
+#pragma once
+
+#include "ftl/ethernet/interface.hpp"
+#include "ftl/ipv4/udp/socket.hpp"
+
+namespace ftl::ethernet {
+
+class NativeEthernetInterface : public Interface {
+public:
+    NativeEthernetInterface(ftl::ipv4::Address address, ftl::ipv4::Mask mask)
+      : ethernet::Interface{address, mask} {}
+    ~NativeEthernetInterface() override = default;
+
+    ftl::ipv4::udp::SocketPtr CreateUdpSocket() override;
+};
+
+}  // namespace ftl::ethernet

--- a/firmware/native/include/ftl/native_udp_socket.hpp
+++ b/firmware/native/include/ftl/native_udp_socket.hpp
@@ -28,8 +28,10 @@ public:
   bool leave_multicast_group(const ftl::ipv4::Address &group) override;
 
 private:
-  int fd_{-1};
   ftl::ethernet::NativeEthernetInterface &interface_;
+  int tx_fd_{ -1 };
+  int rx_multicast_fd_{ -1 };
+  static constexpr int OVERRIDE_TTL = 16;
 };
 
 }  // namespace ftl::ipv4::udp

--- a/firmware/native/include/ftl/native_udp_socket.hpp
+++ b/firmware/native/include/ftl/native_udp_socket.hpp
@@ -11,6 +11,78 @@
 
 namespace ftl::ipv4::udp {
 
+//------------------------------------------------------------------------------
+// NativeUdpSocket
+//
+// This class uses two separate socket descriptors (tx_fd_ and rx_multicast_fd_) 
+// to ensure that both sending and receiving of multicast traffic can be forced 
+// onto a specific local interface (for example, the loopback interface) so that 
+// you can observe the packets in Wireshark. 
+//
+// Overview:
+//
+// 1. tx_fd_ (Transmit Socket)
+//    • Bound explicitly to the chosen interface’s IP address (e.g., 127.0.0.1) 
+//      and the UDP port. 
+//    • IP_MULTICAST_IF is set to that same interface, causing all multicast 
+//      egress to travel out on that interface.
+//    • IP_MULTICAST_LOOP is enabled so that packets sent on loopback will 
+//      loop back to any socket that has joined the group on that interface. 
+//    • Because tx_fd_ is bound to the interface’s address:port, any attempt to 
+//      receive on loopback (e.g., “127.0.0.1:port”) will also catch looped-back 
+//      packets if a socket is bound there.
+//
+// 2. rx_multicast_fd_ (Receive Socket)
+//    • Bound to INADDR_ANY on the same UDP port, with SO_REUSEADDR (and 
+//      optionally SO_REUSEPORT) enabled so that it can share the port with 
+//      tx_fd_. 
+//    • Joins the multicast group on exactly the same interface address used 
+//      by tx_fd_. That ensures the kernel delivers looped-back group packets 
+//      to rx_multicast_fd_. 
+//    • Because it is bound to INADDR_ANY:port, it will receive both multicast 
+//      packets (for which it has joined the group) and any unicast packets 
+//      addressed specifically to the interface’s IP:port.
+//
+// Why two descriptors?
+// --------------------
+// • If you bind a single socket to INADDR_ANY:port and then set IP_MULTICAST_IF 
+//   to loopback, the kernel may choose a different interface for RX, or you 
+//   may not see your own looped-back packets in Wireshark on lo. 
+// • By having tx_fd_ bound to the interface IP:port, all outgoing multicast is 
+//   forced onto that interface. Wireshark sees it on lo (or whichever IF you pick). 
+// • By having rx_multicast_fd_ bound to INADDR_ANY:port with a specific 
+//   IP_ADD_MEMBERSHIP on the same interface, you are guaranteed to receive 
+//   loop-backed multicast on that interface. 
+// • Then, at runtime, we do a non-blocking select() on both tx_fd_ and 
+//   rx_multicast_fd_. Any unicast (to interface IP:port) shows up on tx_fd_, 
+//   any multicast shows up on rx_multicast_fd_. We return whichever arrives first.
+//
+// Potential side effects and caveats:
+// -----------------------------------
+// • Both descriptors share the same UDP port. You **must** enable SO_REUSEADDR 
+//   (and on some platforms SO_REUSEPORT) before calling bind() on each socket, 
+//   or the second bind() will fail with “Address already in use.” 
+// • Because rx_multicast_fd_ is bound to INADDR_ANY, it will also see any 
+//   unicast datagrams sent to the interface’s IP:port. If you only expect 
+//   multicast, be prepared to filter out any stray unicast traffic. 
+// • Packet ordering is not guaranteed between the two sockets. If both a 
+//   multicast and a unicast arrive at the same time, select() will deliver them 
+//   in whichever order the kernel detects. Your application logic should handle 
+//   potential interleaving. 
+// • Slightly higher resource usage (two file descriptors per socket object), 
+//   and extra complexity in receive() because of the select() over two fds. 
+// • If you change the interface after bind(), you must re-join the multicast group 
+//   and/or re-bind tx_fd_ so that IP_MULTICAST_IF matches. Mismatches can cause 
+//   multicast packets not to loop back or not be received. 
+// • Be cautious about IPv4 vs IPv6: this class is IPv4-only. If you need IPv6 
+//   multicast, a different approach is required.
+//
+// In summary, the dual-descriptor approach is necessary to force multicast egress 
+// onto a chosen interface (so you can inspect it in Wireshark) while still 
+// receiving multicast (and unicast) on the same UDP port. Keep in mind the 
+// requirements for port reuse, correct interface choice in IP_ADD_MEMBERSHIP, 
+// and the implications of binding to INADDR_ANY vs a specific IP.
+//
 class NativeUdpSocket final : public Socket {
 public:
   NativeUdpSocket(ftl::ethernet::NativeEthernetInterface &interface) 

--- a/firmware/native/include/ftl/native_udp_socket.hpp
+++ b/firmware/native/include/ftl/native_udp_socket.hpp
@@ -7,12 +7,14 @@
 #include "ftl/ipv4/udp/socket.hpp"
 #include "ftl/ipv4/udp/payload.hpp"
 #include "ftl/ipv4/endpoint.hpp"
+#include "ftl/native_ethernet_interface.hpp"
 
 namespace ftl::ipv4::udp {
 
 class NativeUdpSocket final : public Socket {
 public:
-  NativeUdpSocket();
+  NativeUdpSocket(ftl::ethernet::NativeEthernetInterface &interface) 
+    : interface_{interface} {}
   ~NativeUdpSocket() override;
 
   bool open(std::size_t receive_queue_len = 1) override;
@@ -27,6 +29,7 @@ public:
 
 private:
   int fd_{-1};
+  ftl::ethernet::NativeEthernetInterface &interface_;
 };
 
 }  // namespace ftl::ipv4::udp

--- a/firmware/native/include/ftl/native_udp_socket.hpp
+++ b/firmware/native/include/ftl/native_udp_socket.hpp
@@ -1,0 +1,32 @@
+// native_udp_socket.hpp
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "ftl/ipv4/udp/socket.hpp"
+#include "ftl/ipv4/udp/payload.hpp"
+#include "ftl/ipv4/endpoint.hpp"
+
+namespace ftl::ipv4::udp {
+
+class NativeUdpSocket final : public Socket {
+public:
+  NativeUdpSocket();
+  ~NativeUdpSocket() override;
+
+  bool open(std::size_t receive_queue_len = 1) override;
+  bool is_open() const noexcept override;
+  bool bind(uint16_t port = 0) override;
+  bool send(Payload payload, const ipv4::Endpoint dest) override;
+  Payload receive(ipv4::Endpoint *const peer) override;
+  void close() override;
+
+  bool join_multicast_group(const ftl::ipv4::Address &group) override;
+  bool leave_multicast_group(const ftl::ipv4::Address &group) override;
+
+private:
+  int fd_{-1};
+};
+
+}  // namespace ftl::ipv4::udp

--- a/firmware/native/native_ethernet_interface.cpp
+++ b/firmware/native/native_ethernet_interface.cpp
@@ -1,0 +1,17 @@
+// src/native_ethernet_interface.cpp
+#include "ftl/native_ethernet_interface.hpp"
+#include "ftl/native_udp_socket.hpp"
+#include "ftl/deleter.hpp"
+
+namespace ftl::ethernet {
+
+ftl::ipv4::udp::SocketPtr NativeEthernetInterface::CreateUdpSocket() {
+  // one shared DefaultDeleter instance lives for the program duration
+  static DefaultDeleter<ftl::ipv4::udp::Socket> defaultDeleter{};
+  return ftl::ipv4::udp::SocketPtr{
+    new ftl::ipv4::udp::NativeUdpSocket(*this),
+    DelegatingDeleter<ftl::ipv4::udp::Socket>{ &defaultDeleter }
+  };
+}
+
+}  // namespace ftl::ethernet

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -58,6 +58,10 @@ bool NativeUdpSocket::bind(uint16_t port) {
       return false;
   }
 
+  if (fcntl(fd_, F_SETFL, O_NONBLOCK) < 0) {
+    return false;
+  }
+
   // Set the multicast TTL to OVERRIDE_TTL
   int ttl = OVERRIDE_TTL;
   if (::setsockopt(fd_,
@@ -65,6 +69,18 @@ bool NativeUdpSocket::bind(uint16_t port) {
                    IP_MULTICAST_TTL,
                    &ttl,
                    sizeof(ttl)) < 0)
+  {
+      return false;
+  }
+
+  // Enable loopback of multicast packets (so that a packet you send to 239.0.0.42 on lo will also
+  //    be delivered back to any socket on lo that's in that group).
+  unsigned char loop = 1;
+  if (::setsockopt(fd_,
+                    IPPROTO_IP,
+                    IP_MULTICAST_LOOP,
+                    &loop,
+                    sizeof(loop)) < 0)
   {
       return false;
   }
@@ -102,29 +118,74 @@ bool NativeUdpSocket::send(Payload payload, const ipv4::Endpoint dest) {
     return sent == static_cast<ssize_t>(payload.size());
 }
 
-void NativeUdpSocket::close() {
-    if (fd_ >= 0) {
-        ::close(fd_);
-        fd_ = -1;
+Payload NativeUdpSocket::receive(ipv4::Endpoint *const peer) {
+  if (!is_open()) {
+    return Payload(0);
+  }
+
+  constexpr std::size_t kMaxDatagram = 65507;  // worst‐case UDP payload
+  uint8_t               tmpBuf[kMaxDatagram];
+  sockaddr_in           addr{};
+  socklen_t             addrlen = sizeof(addr);
+
+  ssize_t n = ::recvfrom(fd_, tmpBuf, sizeof(tmpBuf), 0,
+                       (sockaddr*)&addr, &addrlen);
+  if (n < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      // no data ready, return empty immediately
+      return {};
     }
-}
-
-// (Receive and multicast‐join/drop methods can remain unchanged or be removed if not needed.)
-// For this minimal send‐only example, we leave them stubbed out:
-
-Payload NativeUdpSocket::receive(ipv4::Endpoint* const /*peer*/) {
-    // Not used in “send‐only” scenario.
+    // real error
     return {};
+  }
+
+  // Allocate a Payload sized exactly to the received length
+  size_t len = static_cast<size_t>(n);
+  Payload p(len);
+  std::memcpy(p.data(), tmpBuf, len);
+
+  // Fill in peer info (Address ctor takes network-order uint32_t)
+  peer->set_address(Address{ ntohl(addr.sin_addr.s_addr) });
+  peer->set_port   ( ntohs(addr.sin_port) );
+
+  return p;
 }
 
-bool NativeUdpSocket::join_multicast_group(const ftl::ipv4::Address& /*group*/) {
-    // Not used in “send‐only” scenario.
-    return false;
+void NativeUdpSocket::close() {
+  if (fd_ >= 0) {
+    ::close(fd_);
+    fd_ = -1;
+  }
 }
 
-bool NativeUdpSocket::leave_multicast_group(const ftl::ipv4::Address& /*group*/) {
-    // Not used in “send‐only” scenario.
+bool NativeUdpSocket::join_multicast_group(const ftl::ipv4::Address &group) {
+  if (!is_open()) {
+      return false;
+  }
+
+  ip_mreq mreq{};
+  mreq.imr_multiaddr.s_addr = htonl(group.ToUint32());
+
+  // ← Here we explicitly use loopback (“127.0.0.1”) instead of INADDR_ANY:
+  uint32_t loopback_be = htonl(interface_.address().ToUint32());
+  mreq.imr_interface.s_addr = loopback_be;
+
+  return (::setsockopt(fd_,
+                      IPPROTO_IP,
+                      IP_ADD_MEMBERSHIP,
+                      &mreq,
+                      sizeof(mreq)) == 0);
+}
+
+bool NativeUdpSocket::leave_multicast_group(const ftl::ipv4::Address &group) {
+  if (!is_open()) {
     return false;
+  }
+  ip_mreq mreq{};
+  mreq.imr_multiaddr.s_addr = htonl(group.ToUint32());
+  mreq.imr_interface.s_addr = INADDR_ANY;
+  return (::setsockopt(fd_, IPPROTO_IP, IP_DROP_MEMBERSHIP,
+                      &mreq, sizeof(mreq)) == 0);
 }
 
 } // namespace ftl::ipv4::udp

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -47,12 +47,17 @@ bool NativeUdpSocket::bind(uint16_t port) {
   }
 
   // Get the interface address in network order:
-  uint32_t interface_addr = htonl(this->interface_.address().ToUint32());
+  uint32_t interface_addr_int = htonl(this->interface_.address().ToUint32());
+  uint32_t bind_addr_int = interface_addr_int;
+
+  if (port == 9382U) {
+    bind_addr_int = INADDR_ANY;
+  }
 
   // Bind the socket to interface:port
   sockaddr_in bind_addr{};
   bind_addr.sin_family      = AF_INET;
-  bind_addr.sin_addr.s_addr = interface_addr;
+  bind_addr.sin_addr.s_addr = bind_addr_int;
   bind_addr.sin_port        = htons(port);
   if (::bind(fd_, reinterpret_cast<sockaddr*>(&bind_addr), sizeof(bind_addr)) < 0) {
       return false;
@@ -89,8 +94,8 @@ bool NativeUdpSocket::bind(uint16_t port) {
   if (::setsockopt(fd_,
                    IPPROTO_IP,
                    IP_MULTICAST_IF,
-                   &interface_addr,
-                   sizeof(interface_addr)) < 0)
+                   &interface_addr_int,
+                   sizeof(interface_addr_int)) < 0)
   {
       return false;
   }

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -41,7 +41,7 @@ bool NativeUdpSocket::is_open() const noexcept {
     return fd_ >= 0;
 }
 
-bool NativeUdpSocket::bind(uint16_t /*port*/) {
+bool NativeUdpSocket::bind(uint16_t port) {
   if (!is_open()) {
       return false;
   }
@@ -49,11 +49,11 @@ bool NativeUdpSocket::bind(uint16_t /*port*/) {
   // Get the interface address in network order:
   uint32_t interface_addr = htonl(this->interface_.address().ToUint32());
 
-  // Bind the socket to <loopback>:0 (ephemeral port)
+  // Bind the socket to interface:port
   sockaddr_in bind_addr{};
   bind_addr.sin_family      = AF_INET;
   bind_addr.sin_addr.s_addr = interface_addr;
-  bind_addr.sin_port        = htons(0);
+  bind_addr.sin_port        = htons(port);
   if (::bind(fd_, reinterpret_cast<sockaddr*>(&bind_addr), sizeof(bind_addr)) < 0) {
       return false;
   }

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -1,24 +1,15 @@
 // native_udp_socket.cpp
-//
-// Modified to match the minimal working “Hello multicast” example:
-//   • Bind to the loopback interface (e.g. 127.0.0.1:0).
-//   • Set IP_MULTICAST_TTL.
-//   • Set IP_MULTICAST_IF to loopback.
-//   • Provide a simple send-only path (no nonblocking, no receive setup).
-//
-// Build with C++17.
 
 #include "ftl/native_udp_socket.hpp"
 
-#include <arpa/inet.h>   // inet_pton, htonl, htons
-#include <fcntl.h>       // fcntl, O_NONBLOCK
-#include <netinet/in.h>
-#include <sys/socket.h>  // socket, setsockopt, bind, sendto
-#include <unistd.h>      // close
+#include <arpa/inet.h>    // inet_pton, htonl, htons
+#include <fcntl.h>        // fcntl, O_NONBLOCK
+#include <netinet/in.h>   // sockaddr_in, IPPROTO_IP, IP_MULTICAST_TTL, IP_MULTICAST_LOOP, IP_MULTICAST_IF, ip_mreq
+#include <sys/select.h>   // select, fd_set
+#include <sys/socket.h>   // socket, setsockopt, bind, sendto, recvfrom
+#include <unistd.h>       // close
+#include <cerrno>
 #include <cstring>
-#include <iostream>
-
-#define OVERRIDE_TTL 16
 
 namespace ftl::ipv4::udp {
 
@@ -26,19 +17,31 @@ NativeUdpSocket::~NativeUdpSocket() {
     close();
 }
 
-bool NativeUdpSocket::open(std::size_t /*unused*/) {
-    if (fd_ >= 0) {
-        return false; // already open
-    }
-    fd_ = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-    if (fd_ < 0) {
+bool NativeUdpSocket::open(std::size_t /* receive_queue_len */) {
+    // If either FD is already open, fail
+    if (tx_fd_ >= 0 || rx_multicast_fd_ >= 0) {
         return false;
     }
+
+    // 1) Create TX socket
+    tx_fd_ = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (tx_fd_ < 0) {
+        return false;
+    }
+
+    // 2) Create RX socket
+    rx_multicast_fd_ = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (rx_multicast_fd_ < 0) {
+        ::close(tx_fd_);
+        tx_fd_ = -1;
+        return false;
+    }
+
     return true;
 }
 
 bool NativeUdpSocket::is_open() const noexcept {
-    return fd_ >= 0;
+    return (tx_fd_ >= 0 && rx_multicast_fd_ >= 0);
 }
 
 bool NativeUdpSocket::bind(uint16_t port) {
@@ -46,30 +49,86 @@ bool NativeUdpSocket::bind(uint16_t port) {
       return false;
   }
 
-  // Get the interface address in network order:
-  uint32_t interface_addr_int = htonl(this->interface_.address().ToUint32());
-  uint32_t bind_addr_int = interface_addr_int;
-
-  if (port == 9382U) {
-    bind_addr_int = INADDR_ANY;
+  // 1) Enable port reuse on RX socket
+  int opt = 1;
+  if (::setsockopt(rx_multicast_fd_,
+                   SOL_SOCKET,
+                   SO_REUSEADDR,
+                   &opt,
+                   sizeof(opt)) < 0)
+  {
+      return false;
   }
+  // (Optional, if your distro/kernel requires it for true port sharing)
+  #ifdef SO_REUSEPORT
+  if (::setsockopt(rx_multicast_fd_,
+                   SOL_SOCKET,
+                   SO_REUSEPORT,
+                   &opt,
+                   sizeof(opt)) < 0)
+  {
+      return false;
+  }
+  #endif
 
-  // Bind the socket to interface:port
-  sockaddr_in bind_addr{};
-  bind_addr.sin_family      = AF_INET;
-  bind_addr.sin_addr.s_addr = bind_addr_int;
-  bind_addr.sin_port        = htons(port);
-  if (::bind(fd_, reinterpret_cast<sockaddr*>(&bind_addr), sizeof(bind_addr)) < 0) {
+  // Now bind RX to INADDR_ANY:port
+  sockaddr_in rx_addr{};
+  rx_addr.sin_family      = AF_INET;
+  rx_addr.sin_port        = htons(port);
+  rx_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+  if (::bind(rx_multicast_fd_,
+             reinterpret_cast<sockaddr*>(&rx_addr),
+             sizeof(rx_addr)) < 0)
+  {
       return false;
   }
 
-  if (fcntl(fd_, F_SETFL, O_NONBLOCK) < 0) {
-    return false;
+  if (fcntl(rx_multicast_fd_, F_SETFL, O_NONBLOCK) < 0) {
+      return false;
   }
 
-  // Set the multicast TTL to OVERRIDE_TTL
+  // 2) Enable port reuse on TX socket
+  if (::setsockopt(tx_fd_,
+                   SOL_SOCKET,
+                   SO_REUSEADDR,
+                   &opt,
+                   sizeof(opt)) < 0)
+  {
+      return false;
+  }
+  #ifdef SO_REUSEPORT
+  if (::setsockopt(tx_fd_,
+                   SOL_SOCKET,
+                   SO_REUSEPORT,
+                   &opt,
+                   sizeof(opt)) < 0)
+  {
+      return false;
+  }
+  #endif
+
+  // Bind TX to (interface IP):port
+  uint32_t iface_be = htonl(interface_.address().ToUint32());
+  sockaddr_in tx_addr{};
+  tx_addr.sin_family      = AF_INET;
+  tx_addr.sin_port        = htons(port);
+  tx_addr.sin_addr.s_addr = iface_be;
+
+  if (::bind(tx_fd_,
+             reinterpret_cast<sockaddr*>(&tx_addr),
+             sizeof(tx_addr)) < 0)
+  {
+      return false;
+  }
+
+  if (fcntl(tx_fd_, F_SETFL, O_NONBLOCK) < 0) {
+      return false;
+  }
+
+  // 3) Set multicast TTL, loopback, and IF on TX
   int ttl = OVERRIDE_TTL;
-  if (::setsockopt(fd_,
+  if (::setsockopt(tx_fd_,
                    IPPROTO_IP,
                    IP_MULTICAST_TTL,
                    &ttl,
@@ -78,24 +137,21 @@ bool NativeUdpSocket::bind(uint16_t port) {
       return false;
   }
 
-  // Enable loopback of multicast packets (so that a packet you send to 239.0.0.42 on lo will also
-  //    be delivered back to any socket on lo that's in that group).
   unsigned char loop = 1;
-  if (::setsockopt(fd_,
-                    IPPROTO_IP,
-                    IP_MULTICAST_LOOP,
-                    &loop,
-                    sizeof(loop)) < 0)
+  if (::setsockopt(tx_fd_,
+                   IPPROTO_IP,
+                   IP_MULTICAST_LOOP,
+                   &loop,
+                   sizeof(loop)) < 0)
   {
       return false;
   }
 
-  // Tell the kernel to use this loopback interface for multicast egress
-  if (::setsockopt(fd_,
+  if (::setsockopt(tx_fd_,
                    IPPROTO_IP,
                    IP_MULTICAST_IF,
-                   &interface_addr_int,
-                   sizeof(interface_addr_int)) < 0)
+                   &iface_be,
+                   sizeof(iface_be)) < 0)
   {
       return false;
   }
@@ -104,93 +160,135 @@ bool NativeUdpSocket::bind(uint16_t port) {
 }
 
 bool NativeUdpSocket::send(Payload payload, const ipv4::Endpoint dest) {
-    if (!is_open()) {
+    if (tx_fd_ < 0) {
         return false;
     }
 
-    sockaddr_in addr;
-    std::memset(&addr, 0, sizeof(addr));
-    addr.sin_family      = AF_INET;
-    addr.sin_addr.s_addr = htonl(dest.address().ToUint32());
-    addr.sin_port        = htons(dest.port());
+    sockaddr_in dst_addr{};
+    std::memset(&dst_addr, 0, sizeof(dst_addr));
+    dst_addr.sin_family      = AF_INET;
+    dst_addr.sin_addr.s_addr = htonl(dest.address().ToUint32());
+    dst_addr.sin_port        = htons(dest.port());
 
-    ssize_t sent = ::sendto(fd_,
-                            payload.data(),
-                            payload.size(),
-                            0,
-                            reinterpret_cast<sockaddr*>(&addr),
-                            sizeof(addr));
-    return sent == static_cast<ssize_t>(payload.size());
+    ssize_t sent = ::sendto(tx_fd_,
+                             payload.data(),
+                             payload.size(),
+                             0,
+                             reinterpret_cast<const sockaddr*>(&dst_addr),
+                             sizeof(dst_addr));
+    return (sent == static_cast<ssize_t>(payload.size()));
 }
 
 Payload NativeUdpSocket::receive(ipv4::Endpoint *const peer) {
-  if (!is_open()) {
-    return Payload(0);
-  }
-
-  constexpr std::size_t kMaxDatagram = 65507;  // worst‐case UDP payload
-  uint8_t               tmpBuf[kMaxDatagram];
-  sockaddr_in           addr{};
-  socklen_t             addrlen = sizeof(addr);
-
-  ssize_t n = ::recvfrom(fd_, tmpBuf, sizeof(tmpBuf), 0,
-                       (sockaddr*)&addr, &addrlen);
-  if (n < 0) {
-    if (errno == EAGAIN || errno == EWOULDBLOCK) {
-      // no data ready, return empty immediately
-      return {};
+    if (!is_open()) {
+        return Payload(0);
     }
-    // real error
-    return {};
-  }
 
-  // Allocate a Payload sized exactly to the received length
-  size_t len = static_cast<size_t>(n);
-  Payload p(len);
-  std::memcpy(p.data(), tmpBuf, len);
+    // Build fd_set for select
+    fd_set read_fds;
+    FD_ZERO(&read_fds);
+    FD_SET(rx_multicast_fd_, &read_fds);
+    FD_SET(tx_fd_, &read_fds);
 
-  // Fill in peer info (Address ctor takes network-order uint32_t)
-  peer->set_address(Address{ ntohl(addr.sin_addr.s_addr) });
-  peer->set_port   ( ntohs(addr.sin_port) );
+    int max_fd = std::max(rx_multicast_fd_, tx_fd_);
+    timeval timeout{0, 0};  // zero timeout => non‐blocking
 
-  return p;
+    int ready = ::select(max_fd + 1, &read_fds, nullptr, nullptr, &timeout);
+    if (ready < 0) {
+        // Real error
+        return Payload(0);
+    }
+    if (ready == 0) {
+        // No data on either socket
+        return Payload(0);
+    }
+
+    // Prefer RX if both have data
+    int which_fd = -1;
+    if (FD_ISSET(rx_multicast_fd_, &read_fds)) {
+        which_fd = rx_multicast_fd_;
+    } else if (FD_ISSET(tx_fd_, &read_fds)) {
+        which_fd = tx_fd_;
+    }
+
+    if (which_fd < 0) {
+        return Payload(0);
+    }
+
+    constexpr std::size_t kMaxDatagram = 65507;
+    uint8_t tmpBuf[kMaxDatagram];
+    sockaddr_in addr{};
+    socklen_t addrlen = sizeof(addr);
+
+    ssize_t n = ::recvfrom(which_fd,
+                           tmpBuf,
+                           sizeof(tmpBuf),
+                           0,
+                           reinterpret_cast<sockaddr*>(&addr),
+                           &addrlen);
+    if (n < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            // Would block ⇒ no data
+            return Payload(0);
+        }
+        // Real error
+        return Payload(0);
+    }
+
+    size_t len = static_cast<size_t>(n);
+    Payload p(len);
+    std::memcpy(p.data(), tmpBuf, len);
+
+    peer->set_address(Address{ ntohl(addr.sin_addr.s_addr) });
+    peer->set_port(static_cast<uint16_t>(ntohs(addr.sin_port)));
+
+    return p;
 }
 
 void NativeUdpSocket::close() {
-  if (fd_ >= 0) {
-    ::close(fd_);
-    fd_ = -1;
-  }
+    if (tx_fd_ >= 0) {
+        ::close(tx_fd_);
+        tx_fd_ = -1;
+    }
+    if (rx_multicast_fd_ >= 0) {
+        ::close(rx_multicast_fd_);
+        rx_multicast_fd_ = -1;
+    }
 }
 
 bool NativeUdpSocket::join_multicast_group(const ftl::ipv4::Address &group) {
-  if (!is_open()) {
+  if (rx_multicast_fd_ < 0) { return false; }
+
+  ip_mreq mreq{};
+  mreq.imr_multiaddr.s_addr = htonl(group.ToUint32());
+
+  uint32_t iface_be = htonl(interface_.address().ToUint32());
+  mreq.imr_interface.s_addr = iface_be;
+
+  return (::setsockopt(rx_multicast_fd_,
+                       IPPROTO_IP,
+                       IP_ADD_MEMBERSHIP,
+                       &mreq,
+                       sizeof(mreq)) == 0);
+}
+
+bool NativeUdpSocket::leave_multicast_group(const ftl::ipv4::Address &group) {
+  if (rx_multicast_fd_ < 0) {
       return false;
   }
 
   ip_mreq mreq{};
   mreq.imr_multiaddr.s_addr = htonl(group.ToUint32());
 
-  // ← Here we explicitly use loopback (“127.0.0.1”) instead of INADDR_ANY:
-  uint32_t loopback_be = htonl(interface_.address().ToUint32());
-  mreq.imr_interface.s_addr = loopback_be;
+  // Must drop on the *same* interface we joined on:
+  uint32_t iface_be = htonl(interface_.address().ToUint32());
+  mreq.imr_interface.s_addr = iface_be;
 
-  return (::setsockopt(fd_,
-                      IPPROTO_IP,
-                      IP_ADD_MEMBERSHIP,
-                      &mreq,
-                      sizeof(mreq)) == 0);
+  return (::setsockopt(rx_multicast_fd_,
+                       IPPROTO_IP,
+                       IP_DROP_MEMBERSHIP,
+                       &mreq,
+                       sizeof(mreq)) == 0);
 }
 
-bool NativeUdpSocket::leave_multicast_group(const ftl::ipv4::Address &group) {
-  if (!is_open()) {
-    return false;
-  }
-  ip_mreq mreq{};
-  mreq.imr_multiaddr.s_addr = htonl(group.ToUint32());
-  mreq.imr_interface.s_addr = INADDR_ANY;
-  return (::setsockopt(fd_, IPPROTO_IP, IP_DROP_MEMBERSHIP,
-                      &mreq, sizeof(mreq)) == 0);
-}
-
-} // namespace ftl::ipv4::udp
+}  // namespace ftl::ipv4::udp

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -179,7 +179,7 @@ bool NativeUdpSocket::send(Payload payload, const ipv4::Endpoint dest) {
 
     // sendto() on tx_fd_. If the return doesn’t match payload.size(), treat as failure.
     ssize_t sent = ::sendto(tx_fd_,
-                             payload.data(),
+                             payload.front(),
                              payload.size(),
                              0,
                              reinterpret_cast<const sockaddr*>(&dst_addr),
@@ -252,7 +252,7 @@ Payload NativeUdpSocket::receive(ipv4::Endpoint *const peer) {
     // Copy the received data into a Payload of exactly the right size.
     size_t len = static_cast<size_t>(n);
     Payload p(len);
-    std::memcpy(p.data(), tmpBuf, len);
+    std::memcpy(p.front(), tmpBuf, len);
 
     // Populate the peer endpoint (host-order address and port).
     peer->set_address(Address{ ntohl(addr.sin_addr.s_addr) });

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -41,54 +41,46 @@ bool NativeUdpSocket::is_open() const noexcept {
     return fd_ >= 0;
 }
 
-/// Bind to the loopback interface on port 0 (ephemeral).
-/// Then set TTL and multicast‐IF exactly as in the working example.
 bool NativeUdpSocket::bind(uint16_t /*port*/) {
-    if (!is_open()) {
-        return false;
-    }
+  if (!is_open()) {
+      return false;
+  }
 
-    // 1) Bind to <loopback>:0
-    in_addr tmp;
-    if (::inet_pton(AF_INET, "127.0.0.1", &tmp) != 1) {
-        // Should never fail for "127.0.0.1"
-        return false;
-    }
-    uint32_t loopback_be = tmp.s_addr; // already network‐order
+  // 1) Figure out our loopback address in network order:
+  uint32_t loopback_hbo = this->interface_.address().ToUint32(); // host‐byte‐order
+  uint32_t loopback_be  = htonl(loopback_hbo);
 
-    sockaddr_in bind_addr;
-    std::memset(&bind_addr, 0, sizeof(bind_addr));
-    bind_addr.sin_family      = AF_INET;
-    bind_addr.sin_addr.s_addr = loopback_be;
-    bind_addr.sin_port        = htons(0);
+  // 2) Bind the socket to <loopback>:0 (ephemeral port)
+  sockaddr_in bind_addr{};
+  bind_addr.sin_family      = AF_INET;
+  bind_addr.sin_addr.s_addr = loopback_be;
+  bind_addr.sin_port        = htons(0);
+  if (::bind(fd_, reinterpret_cast<sockaddr*>(&bind_addr), sizeof(bind_addr)) < 0) {
+      return false;
+  }
 
-    if (::bind(fd_, reinterpret_cast<sockaddr*>(&bind_addr), sizeof(bind_addr)) < 0) {
-        return false;
-    }
+  // 3) Set the multicast TTL to OVERRIDE_TTL
+  int ttl = OVERRIDE_TTL;
+  if (::setsockopt(fd_,
+                   IPPROTO_IP,
+                   IP_MULTICAST_TTL,
+                   &ttl,
+                   sizeof(ttl)) < 0)
+  {
+      return false;
+  }
 
-    // 2) Set multicast TTL = OVERRIDE_TTL
-    int ttl = OVERRIDE_TTL;
-    if (::setsockopt(fd_,
-                     IPPROTO_IP,
-                     IP_MULTICAST_TTL,
-                     &ttl,
-                     sizeof(ttl)) < 0)
-    {
-        return false;
-    }
+  // 4) Tell the kernel to use this loopback interface for multicast egress
+  if (::setsockopt(fd_,
+                   IPPROTO_IP,
+                   IP_MULTICAST_IF,
+                   &loopback_be,
+                   sizeof(loopback_be)) < 0)
+  {
+      return false;
+  }
 
-    // 3) Tell kernel to use loopback for multicast egress
-    //    We already have loopback_be in network‐order.
-    if (::setsockopt(fd_,
-                     IPPROTO_IP,
-                     IP_MULTICAST_IF,
-                     &loopback_be,
-                     sizeof(loopback_be)) < 0)
-    {
-        return false;
-    }
-
-    return true;
+  return true;
 }
 
 bool NativeUdpSocket::send(Payload payload, const ipv4::Endpoint dest) {

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -181,7 +181,7 @@ bool NativeUdpSocket::send(Payload payload, const ipv4::Endpoint dest) {
 
 Payload NativeUdpSocket::receive(ipv4::Endpoint *const peer) {
     if (!is_open()) {
-        return Payload(0);
+        return {};
     }
 
     // Build fd_set for select
@@ -196,11 +196,11 @@ Payload NativeUdpSocket::receive(ipv4::Endpoint *const peer) {
     int ready = ::select(max_fd + 1, &read_fds, nullptr, nullptr, &timeout);
     if (ready < 0) {
         // Real error
-        return Payload(0);
+        return {};
     }
     if (ready == 0) {
         // No data on either socket
-        return Payload(0);
+        return {};
     }
 
     // Prefer RX if both have data
@@ -212,7 +212,7 @@ Payload NativeUdpSocket::receive(ipv4::Endpoint *const peer) {
     }
 
     if (which_fd < 0) {
-        return Payload(0);
+        return {};
     }
 
     constexpr std::size_t kMaxDatagram = 65507;
@@ -229,10 +229,10 @@ Payload NativeUdpSocket::receive(ipv4::Endpoint *const peer) {
     if (n < 0) {
         if (errno == EAGAIN || errno == EWOULDBLOCK) {
             // Would block ⇒ no data
-            return Payload(0);
+            return {};
         }
         // Real error
-        return Payload(0);
+        return {};
     }
 
     size_t len = static_cast<size_t>(n);

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -4,8 +4,11 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <cstring>
+
+#include <iostream>
 
 namespace ftl::ipv4::udp {
 
@@ -34,6 +37,11 @@ bool NativeUdpSocket::open(std::size_t receive_queue_len) {
   int buf_bytes = static_cast<int>(receive_queue_len) * kMaxDatagram;
   ::setsockopt(fd_, SOL_SOCKET, SO_RCVBUF, &buf_bytes, sizeof(buf_bytes));
 
+  // Make the socket non-blocking
+  int flags = fcntl(fd_, F_GETFL, 0);
+  if (flags < 0) return false;
+  if (fcntl(fd_, F_SETFL, flags | O_NONBLOCK) < 0) return false;
+
   return true;
 }
 
@@ -61,6 +69,7 @@ bool NativeUdpSocket::send(Payload payload, const ipv4::Endpoint dest) {
   }
   sockaddr_in addr{};
   addr.sin_family = AF_INET;
+  std::cout << "sending to: " << dest.address().ToUint32() << std::endl;
   addr.sin_addr.s_addr = dest.address().ToUint32();
   addr.sin_port = htons(dest.port());
   auto sent = ::sendto(fd_,
@@ -77,53 +86,31 @@ Payload NativeUdpSocket::receive(ipv4::Endpoint *const peer) {
     return Payload(0);
   }
 
-  // 1) Peek the next datagram’s full length
-  sockaddr_in addr{};
-  socklen_t addrlen = sizeof(addr);
+  constexpr std::size_t kMaxDatagram = 65507;  // worst‐case UDP payload
+  uint8_t               tmpBuf[kMaxDatagram];
+  sockaddr_in           addr{};
+  socklen_t             addrlen = sizeof(addr);
 
-  // A 1-byte buffer just to satisfy recvmsg; MSG_TRUNC makes the return
-  // value the real length of the whole datagram, regardless of iov_len.
-  uint8_t  tmp;
-  iovec    iov{ &tmp, 1 };
-  msghdr   msg{};
-  msg.msg_name    = &addr;
-  msg.msg_namelen = addrlen;
-  msg.msg_iov     = &iov;
-  msg.msg_iovlen  = 1;
-
-  ssize_t peek_len = ::recvmsg(fd_, &msg, MSG_PEEK | MSG_TRUNC);
-  if (peek_len < 0) {
-    return Payload(0);
+  // This will block until a full datagram arrives, then return its exact length.
+  ssize_t n = ::recvfrom(fd_, tmpBuf, sizeof(tmpBuf), 0,
+                       (sockaddr*)&addr, &addrlen);
+  if (n < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      // no data ready, return empty immediately
+      return {};
+    }
+    // real error
+    return {};
   }
 
-  size_t packet_len = static_cast<size_t>(peek_len);
-  // Guard against absurd sizes
-  constexpr size_t kMaxDatagram = 65507;
-  if (packet_len > kMaxDatagram) {
-    packet_len = kMaxDatagram;
-  }
+  // Allocate a Payload sized exactly to the received length
+  size_t len = static_cast<size_t>(n);
+  Payload p(len);
+  std::memcpy(p.data(), tmpBuf, len);
 
-  // 2) Allocate exactly the right size
-  Payload p(packet_len);
-
-  // 3) Now actually receive it
-  auto n = ::recvfrom(
-    fd_,
-    p.data(),
-    packet_len,
-    0,
-    reinterpret_cast<sockaddr*>(&addr),
-    &addrlen
-  );
-  if (n < 0 || static_cast<size_t>(n) != packet_len) {
-    return Payload(0);
-  }
-
-  // 4) Fill in peer address and port
-  char addr_str[INET_ADDRSTRLEN];
-  inet_ntop(AF_INET, &addr.sin_addr, addr_str, sizeof(addr_str));
-  peer->set_address(addr_str);
-  peer->set_port(ntohs(addr.sin_port));
+  // Fill in peer info (Address ctor takes network-order uint32_t)
+  peer->set_address(Address{ addr.sin_addr.s_addr });
+  peer->set_port   ( ntohs(addr.sin_port) );
 
   return p;
 }

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -12,8 +12,6 @@
 
 namespace ftl::ipv4::udp {
 
-NativeUdpSocket::NativeUdpSocket() = default;
-
 NativeUdpSocket::~NativeUdpSocket() {
   close();
 }
@@ -55,7 +53,7 @@ bool NativeUdpSocket::bind(uint16_t port) {
   }
   sockaddr_in addr{};
   addr.sin_family = AF_INET;
-  addr.sin_addr.s_addr = INADDR_ANY;
+  addr.sin_addr.s_addr = htonl(this->interface_.address().ToUint32());
   addr.sin_port = htons(port);
   if (::bind(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
     return false;

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -69,7 +69,6 @@ bool NativeUdpSocket::send(Payload payload, const ipv4::Endpoint dest) {
   }
   sockaddr_in addr{};
   addr.sin_family = AF_INET;
-  std::cout << "sending to: " << dest.address().ToUint32() << std::endl;
   addr.sin_addr.s_addr = dest.address().ToUint32();
   addr.sin_port = htons(dest.port());
   auto sent = ::sendto(fd_,

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -1,149 +1,139 @@
 // native_udp_socket.cpp
+//
+// Modified to match the minimal working “Hello multicast” example:
+//   • Bind to the loopback interface (e.g. 127.0.0.1:0).
+//   • Set IP_MULTICAST_TTL.
+//   • Set IP_MULTICAST_IF to loopback.
+//   • Provide a simple send-only path (no nonblocking, no receive setup).
+//
+// Build with C++17.
+
 #include "ftl/native_udp_socket.hpp"
 
-#include <sys/socket.h>
+#include <arpa/inet.h>   // inet_pton, htonl, htons
+#include <fcntl.h>       // fcntl, O_NONBLOCK
 #include <netinet/in.h>
-#include <arpa/inet.h>
-#include <fcntl.h>
-#include <unistd.h>
+#include <sys/socket.h>  // socket, setsockopt, bind, sendto
+#include <unistd.h>      // close
 #include <cstring>
-
 #include <iostream>
+
+#define OVERRIDE_TTL 16
 
 namespace ftl::ipv4::udp {
 
 NativeUdpSocket::~NativeUdpSocket() {
-  close();
+    close();
 }
 
-bool NativeUdpSocket::open(std::size_t receive_queue_len) {
-  if (fd_ >= 0) {
-    return false;  // already open
-  }
-  fd_ = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-  if (fd_ < 0) {
-    return false;
-  }
-
-  // allow immediate rebinding of the same address/port
-  int opt = 1;
-  ::setsockopt(fd_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
-
-  // UDP receive queue length is in *datagrams*, but SO_RCVBUF is in *bytes*.
-  // To hold receive_queue_len datagrams of up to kMaxDatagram bytes each:
-  constexpr int kMaxDatagram = 65507;  // Maximum safe UDP payload
-  int buf_bytes = static_cast<int>(receive_queue_len) * kMaxDatagram;
-  ::setsockopt(fd_, SOL_SOCKET, SO_RCVBUF, &buf_bytes, sizeof(buf_bytes));
-
-  // Make the socket non-blocking
-  int flags = fcntl(fd_, F_GETFL, 0);
-  if (flags < 0) return false;
-  if (fcntl(fd_, F_SETFL, flags | O_NONBLOCK) < 0) return false;
-
-  return true;
+bool NativeUdpSocket::open(std::size_t /*unused*/) {
+    if (fd_ >= 0) {
+        return false; // already open
+    }
+    fd_ = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (fd_ < 0) {
+        return false;
+    }
+    return true;
 }
 
 bool NativeUdpSocket::is_open() const noexcept {
-  return fd_ >= 0;
+    return fd_ >= 0;
 }
 
-bool NativeUdpSocket::bind(uint16_t port) {
-  if (!is_open()) {
-    return false;
-  }
+/// Bind to the loopback interface on port 0 (ephemeral).
+/// Then set TTL and multicast‐IF exactly as in the working example.
+bool NativeUdpSocket::bind(uint16_t /*port*/) {
+    if (!is_open()) {
+        return false;
+    }
 
-  // We need to bind INADDR_ANY to support multicast.
-  //
-  // NOTE: This is a problem for this socket interface design because it can't actually bind a
-  // specific interface, but since port is unique, should be alright.
-  sockaddr_in addr{};
-  addr.sin_family = AF_INET;
-  addr.sin_addr.s_addr = INADDR_ANY;
-  addr.sin_port = htons(port);
-  if (::bind(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
-    return false;
-  }
+    // 1) Bind to <loopback>:0
+    in_addr tmp;
+    if (::inet_pton(AF_INET, "127.0.0.1", &tmp) != 1) {
+        // Should never fail for "127.0.0.1"
+        return false;
+    }
+    uint32_t loopback_be = tmp.s_addr; // already network‐order
 
-  return true;
+    sockaddr_in bind_addr;
+    std::memset(&bind_addr, 0, sizeof(bind_addr));
+    bind_addr.sin_family      = AF_INET;
+    bind_addr.sin_addr.s_addr = loopback_be;
+    bind_addr.sin_port        = htons(0);
+
+    if (::bind(fd_, reinterpret_cast<sockaddr*>(&bind_addr), sizeof(bind_addr)) < 0) {
+        return false;
+    }
+
+    // 2) Set multicast TTL = OVERRIDE_TTL
+    int ttl = OVERRIDE_TTL;
+    if (::setsockopt(fd_,
+                     IPPROTO_IP,
+                     IP_MULTICAST_TTL,
+                     &ttl,
+                     sizeof(ttl)) < 0)
+    {
+        return false;
+    }
+
+    // 3) Tell kernel to use loopback for multicast egress
+    //    We already have loopback_be in network‐order.
+    if (::setsockopt(fd_,
+                     IPPROTO_IP,
+                     IP_MULTICAST_IF,
+                     &loopback_be,
+                     sizeof(loopback_be)) < 0)
+    {
+        return false;
+    }
+
+    return true;
 }
 
 bool NativeUdpSocket::send(Payload payload, const ipv4::Endpoint dest) {
-  if (!is_open()) {
-    return false;
-  }
-  sockaddr_in addr{};
-  addr.sin_family = AF_INET;
-  addr.sin_addr.s_addr = htonl(dest.address().ToUint32());
-  addr.sin_port = htons(dest.port());
-  auto sent = ::sendto(fd_,
-                       payload.data(),
-                       payload.size(),
-                       0,
-                       reinterpret_cast<sockaddr*>(&addr),
-                       sizeof(addr));
-  return sent == static_cast<ssize_t>(payload.size());
-}
-
-Payload NativeUdpSocket::receive(ipv4::Endpoint *const peer) {
-  if (!is_open()) {
-    return Payload(0);
-  }
-
-  constexpr std::size_t kMaxDatagram = 65507;  // worst‐case UDP payload
-  uint8_t               tmpBuf[kMaxDatagram];
-  sockaddr_in           addr{};
-  socklen_t             addrlen = sizeof(addr);
-
-  ssize_t n = ::recvfrom(fd_, tmpBuf, sizeof(tmpBuf), 0,
-                       (sockaddr*)&addr, &addrlen);
-  if (n < 0) {
-    if (errno == EAGAIN || errno == EWOULDBLOCK) {
-      // no data ready, return empty immediately
-      return {};
+    if (!is_open()) {
+        return false;
     }
-    // real error
-    return {};
-  }
 
-  // Allocate a Payload sized exactly to the received length
-  size_t len = static_cast<size_t>(n);
-  Payload p(len);
-  std::memcpy(p.data(), tmpBuf, len);
+    sockaddr_in addr;
+    std::memset(&addr, 0, sizeof(addr));
+    addr.sin_family      = AF_INET;
+    addr.sin_addr.s_addr = htonl(dest.address().ToUint32());
+    addr.sin_port        = htons(dest.port());
 
-  // Fill in peer info (Address ctor takes network-order uint32_t)
-  peer->set_address(Address{ ntohl(addr.sin_addr.s_addr) });
-  peer->set_port   ( ntohs(addr.sin_port) );
-
-  return p;
+    ssize_t sent = ::sendto(fd_,
+                            payload.data(),
+                            payload.size(),
+                            0,
+                            reinterpret_cast<sockaddr*>(&addr),
+                            sizeof(addr));
+    return sent == static_cast<ssize_t>(payload.size());
 }
 
 void NativeUdpSocket::close() {
-  if (fd_ >= 0) {
-    ::close(fd_);
-    fd_ = -1;
-  }
+    if (fd_ >= 0) {
+        ::close(fd_);
+        fd_ = -1;
+    }
 }
 
-bool NativeUdpSocket::join_multicast_group(const ftl::ipv4::Address &group) {
-  if (!is_open()) {
+// (Receive and multicast‐join/drop methods can remain unchanged or be removed if not needed.)
+// For this minimal send‐only example, we leave them stubbed out:
+
+Payload NativeUdpSocket::receive(ipv4::Endpoint* const /*peer*/) {
+    // Not used in “send‐only” scenario.
+    return {};
+}
+
+bool NativeUdpSocket::join_multicast_group(const ftl::ipv4::Address& /*group*/) {
+    // Not used in “send‐only” scenario.
     return false;
-  }
-  ip_mreq mreq{};
-  mreq.imr_multiaddr.s_addr = htonl(group.ToUint32());
-  mreq.imr_interface.s_addr = INADDR_ANY;
-  return (::setsockopt(fd_, IPPROTO_IP, IP_ADD_MEMBERSHIP,
-                      &mreq, sizeof(mreq)) == 0);
 }
 
-bool NativeUdpSocket::leave_multicast_group(const ftl::ipv4::Address &group) {
-  if (!is_open()) {
+bool NativeUdpSocket::leave_multicast_group(const ftl::ipv4::Address& /*group*/) {
+    // Not used in “send‐only” scenario.
     return false;
-  }
-  ip_mreq mreq{};
-  mreq.imr_multiaddr.s_addr = htonl(group.ToUint32());
-  mreq.imr_interface.s_addr = INADDR_ANY;
-  return (::setsockopt(fd_, IPPROTO_IP, IP_DROP_MEMBERSHIP,
-                      &mreq, sizeof(mreq)) == 0);
 }
 
-}  // namespace ftl::ipv4::udp
+} // namespace ftl::ipv4::udp

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -69,7 +69,7 @@ bool NativeUdpSocket::send(Payload payload, const ipv4::Endpoint dest) {
   }
   sockaddr_in addr{};
   addr.sin_family = AF_INET;
-  addr.sin_addr.s_addr = dest.address().ToUint32();
+  addr.sin_addr.s_addr = htonl(dest.address().ToUint32());
   addr.sin_port = htons(dest.port());
   auto sent = ::sendto(fd_,
                        payload.data(),

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -125,7 +125,7 @@ bool NativeUdpSocket::join_multicast_group(const ftl::ipv4::Address &group) {
     return false;
   }
   ip_mreq mreq{};
-  mreq.imr_multiaddr.s_addr = group.ToUint32();
+  mreq.imr_multiaddr.s_addr = htonl(group.ToUint32());
   mreq.imr_interface.s_addr = INADDR_ANY;
   return (::setsockopt(fd_, IPPROTO_IP, IP_ADD_MEMBERSHIP,
                       &mreq, sizeof(mreq)) == 0);
@@ -136,7 +136,7 @@ bool NativeUdpSocket::leave_multicast_group(const ftl::ipv4::Address &group) {
     return false;
   }
   ip_mreq mreq{};
-  mreq.imr_multiaddr.s_addr = group.ToUint32();
+  mreq.imr_multiaddr.s_addr = htonl(group.ToUint32());
   mreq.imr_interface.s_addr = INADDR_ANY;
   return (::setsockopt(fd_, IPPROTO_IP, IP_DROP_MEMBERSHIP,
                       &mreq, sizeof(mreq)) == 0);

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -90,7 +90,6 @@ Payload NativeUdpSocket::receive(ipv4::Endpoint *const peer) {
   sockaddr_in           addr{};
   socklen_t             addrlen = sizeof(addr);
 
-  // This will block until a full datagram arrives, then return its exact length.
   ssize_t n = ::recvfrom(fd_, tmpBuf, sizeof(tmpBuf), 0,
                        (sockaddr*)&addr, &addrlen);
   if (n < 0) {
@@ -108,7 +107,7 @@ Payload NativeUdpSocket::receive(ipv4::Endpoint *const peer) {
   std::memcpy(p.data(), tmpBuf, len);
 
   // Fill in peer info (Address ctor takes network-order uint32_t)
-  peer->set_address(Address{ addr.sin_addr.s_addr });
+  peer->set_address(Address{ ntohl(addr.sin_addr.s_addr) });
   peer->set_port   ( ntohs(addr.sin_port) );
 
   return p;

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -51,13 +51,19 @@ bool NativeUdpSocket::bind(uint16_t port) {
   if (!is_open()) {
     return false;
   }
+
+  // We need to bind INADDR_ANY to support multicast.
+  //
+  // NOTE: This is a problem for this socket interface design because it can't actually bind a
+  // specific interface, but since port is unique, should be alright.
   sockaddr_in addr{};
   addr.sin_family = AF_INET;
-  addr.sin_addr.s_addr = htonl(this->interface_.address().ToUint32());
+  addr.sin_addr.s_addr = INADDR_ANY;
   addr.sin_port = htons(port);
   if (::bind(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
     return false;
   }
+
   return true;
 }
 

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -46,20 +46,19 @@ bool NativeUdpSocket::bind(uint16_t /*port*/) {
       return false;
   }
 
-  // 1) Figure out our loopback address in network order:
-  uint32_t loopback_hbo = this->interface_.address().ToUint32(); // host‐byte‐order
-  uint32_t loopback_be  = htonl(loopback_hbo);
+  // Get the interface address in network order:
+  uint32_t interface_addr = htonl(this->interface_.address().ToUint32());
 
-  // 2) Bind the socket to <loopback>:0 (ephemeral port)
+  // Bind the socket to <loopback>:0 (ephemeral port)
   sockaddr_in bind_addr{};
   bind_addr.sin_family      = AF_INET;
-  bind_addr.sin_addr.s_addr = loopback_be;
+  bind_addr.sin_addr.s_addr = interface_addr;
   bind_addr.sin_port        = htons(0);
   if (::bind(fd_, reinterpret_cast<sockaddr*>(&bind_addr), sizeof(bind_addr)) < 0) {
       return false;
   }
 
-  // 3) Set the multicast TTL to OVERRIDE_TTL
+  // Set the multicast TTL to OVERRIDE_TTL
   int ttl = OVERRIDE_TTL;
   if (::setsockopt(fd_,
                    IPPROTO_IP,
@@ -70,12 +69,12 @@ bool NativeUdpSocket::bind(uint16_t /*port*/) {
       return false;
   }
 
-  // 4) Tell the kernel to use this loopback interface for multicast egress
+  // Tell the kernel to use this loopback interface for multicast egress
   if (::setsockopt(fd_,
                    IPPROTO_IP,
                    IP_MULTICAST_IF,
-                   &loopback_be,
-                   sizeof(loopback_be)) < 0)
+                   &interface_addr,
+                   sizeof(interface_addr)) < 0)
   {
       return false;
   }

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -13,25 +13,29 @@
 
 namespace ftl::ipv4::udp {
 
+// Destructor: ensure both TX and RX sockets are closed when the object is destroyed.
 NativeUdpSocket::~NativeUdpSocket() {
     close();
 }
 
+// open(): create two sockets—one for transmit (tx_fd_) and one for receive (rx_multicast_fd_).
+// Returns false if either socket already exists or if socket() fails.
 bool NativeUdpSocket::open(std::size_t /* receive_queue_len */) {
-    // If either FD is already open, fail
+    // If either descriptor is already open, we fail.
     if (tx_fd_ >= 0 || rx_multicast_fd_ >= 0) {
         return false;
     }
 
-    // 1) Create TX socket
+    // 1) Create the transmit socket as IPv4 UDP.
     tx_fd_ = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
     if (tx_fd_ < 0) {
         return false;
     }
 
-    // 2) Create RX socket
+    // 2) Create the receive socket as IPv4 UDP.
     rx_multicast_fd_ = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
     if (rx_multicast_fd_ < 0) {
+        // If RX creation fails, close TX and return false.
         ::close(tx_fd_);
         tx_fd_ = -1;
         return false;
@@ -40,136 +44,140 @@ bool NativeUdpSocket::open(std::size_t /* receive_queue_len */) {
     return true;
 }
 
+// is_open(): return true only if both TX and RX descriptors are valid (>= 0).
 bool NativeUdpSocket::is_open() const noexcept {
     return (tx_fd_ >= 0 && rx_multicast_fd_ >= 0);
 }
 
+// bind(): bind both RX and TX sockets to the given port. RX is bound to INADDR_ANY,
+// TX is bound to the interface’s IP. Enable port reuse on both sockets to allow
+// two sockets sharing the same port. Also set nonblocking and multicast options.
 bool NativeUdpSocket::bind(uint16_t port) {
-  if (!is_open()) {
-      return false;
-  }
+    if (!is_open()) {
+        return false;
+    }
 
-  // 1) Enable port reuse on RX socket
-  int opt = 1;
-  if (::setsockopt(rx_multicast_fd_,
-                   SOL_SOCKET,
-                   SO_REUSEADDR,
-                   &opt,
-                   sizeof(opt)) < 0)
-  {
-      return false;
-  }
-  // (Optional, if your distro/kernel requires it for true port sharing)
-  #ifdef SO_REUSEPORT
-  if (::setsockopt(rx_multicast_fd_,
-                   SOL_SOCKET,
-                   SO_REUSEPORT,
-                   &opt,
-                   sizeof(opt)) < 0)
-  {
-      return false;
-  }
-  #endif
+    // Enable SO_REUSEADDR and SO_REUSEPORT on the RX socket so it can bind to the same
+    // port as TX.
+    int opt = 1;
+    if (::setsockopt(rx_multicast_fd_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0)
+    {
+        return false;
+    }
+    if (::setsockopt(rx_multicast_fd_, SOL_SOCKET, SO_REUSEPORT, &opt, sizeof(opt)) < 0)
+    {
+        return false;
+    }
 
-  // Now bind RX to INADDR_ANY:port
-  sockaddr_in rx_addr{};
-  rx_addr.sin_family      = AF_INET;
-  rx_addr.sin_port        = htons(port);
-  rx_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    // Bind RX socket to INADDR_ANY:port so that it can receive both unicast and
+    // multicast traffic on any local address.
+    sockaddr_in rx_addr{};
+    rx_addr.sin_family      = AF_INET;
+    rx_addr.sin_port        = htons(port);
+    rx_addr.sin_addr.s_addr = htonl(INADDR_ANY);
 
-  if (::bind(rx_multicast_fd_,
-             reinterpret_cast<sockaddr*>(&rx_addr),
-             sizeof(rx_addr)) < 0)
-  {
-      return false;
-  }
+    if (::bind(rx_multicast_fd_,
+               reinterpret_cast<sockaddr*>(&rx_addr),
+               sizeof(rx_addr)) < 0)
+    {
+        return false;
+    }
 
-  if (fcntl(rx_multicast_fd_, F_SETFL, O_NONBLOCK) < 0) {
-      return false;
-  }
+    // Set RX socket to nonblocking mode so receive() can poll without blocking.
+    if (fcntl(rx_multicast_fd_, F_SETFL, O_NONBLOCK) < 0) {
+        return false;
+    }
 
-  // 2) Enable port reuse on TX socket
-  if (::setsockopt(tx_fd_,
-                   SOL_SOCKET,
-                   SO_REUSEADDR,
-                   &opt,
-                   sizeof(opt)) < 0)
-  {
-      return false;
-  }
-  #ifdef SO_REUSEPORT
-  if (::setsockopt(tx_fd_,
-                   SOL_SOCKET,
-                   SO_REUSEPORT,
-                   &opt,
-                   sizeof(opt)) < 0)
-  {
-      return false;
-  }
-  #endif
+    // Enable SO_REUSEADDR and SO_REUSEPORT on the TX socket so it can bind to the same port as RX.
+    if (::setsockopt(tx_fd_,
+                     SOL_SOCKET,
+                     SO_REUSEADDR,
+                     &opt,
+                     sizeof(opt)) < 0)
+    {
+        return false;
+    }
 
-  // Bind TX to (interface IP):port
-  uint32_t iface_be = htonl(interface_.address().ToUint32());
-  sockaddr_in tx_addr{};
-  tx_addr.sin_family      = AF_INET;
-  tx_addr.sin_port        = htons(port);
-  tx_addr.sin_addr.s_addr = iface_be;
+    if (::setsockopt(tx_fd_,
+                     SOL_SOCKET,
+                     SO_REUSEPORT,
+                     &opt,
+                     sizeof(opt)) < 0)
+    {
+        return false;
+    }
 
-  if (::bind(tx_fd_,
-             reinterpret_cast<sockaddr*>(&tx_addr),
-             sizeof(tx_addr)) < 0)
-  {
-      return false;
-  }
+    // Bind TX socket to the specific interface’s IP:port. This forces outgoing multicast to egress
+    // on that interface so you can see it in Wireshark.
+    uint32_t iface_be = htonl(interface_.address().ToUint32());
+    sockaddr_in tx_addr{};
+    tx_addr.sin_family      = AF_INET;
+    tx_addr.sin_port        = htons(port);
+    tx_addr.sin_addr.s_addr = iface_be;
 
-  if (fcntl(tx_fd_, F_SETFL, O_NONBLOCK) < 0) {
-      return false;
-  }
+    if (::bind(tx_fd_,
+               reinterpret_cast<sockaddr*>(&tx_addr),
+               sizeof(tx_addr)) < 0)
+    {
+        return false;
+    }
 
-  // 3) Set multicast TTL, loopback, and IF on TX
-  int ttl = OVERRIDE_TTL;
-  if (::setsockopt(tx_fd_,
-                   IPPROTO_IP,
-                   IP_MULTICAST_TTL,
-                   &ttl,
-                   sizeof(ttl)) < 0)
-  {
-      return false;
-  }
+    // Set TX socket to nonblocking to match RX behavior.
+    if (fcntl(tx_fd_, F_SETFL, O_NONBLOCK) < 0) {
+        return false;
+    }
 
-  unsigned char loop = 1;
-  if (::setsockopt(tx_fd_,
-                   IPPROTO_IP,
-                   IP_MULTICAST_LOOP,
-                   &loop,
-                   sizeof(loop)) < 0)
-  {
-      return false;
-  }
+    // Configure multicast TTL on TX (limiting how many routers can forward).
+    int ttl = OVERRIDE_TTL;
+    if (::setsockopt(tx_fd_,
+                     IPPROTO_IP,
+                     IP_MULTICAST_TTL,
+                     &ttl,
+                     sizeof(ttl)) < 0)
+    {
+        return false;
+    }
 
-  if (::setsockopt(tx_fd_,
-                   IPPROTO_IP,
-                   IP_MULTICAST_IF,
-                   &iface_be,
-                   sizeof(iface_be)) < 0)
-  {
-      return false;
-  }
+    // Enable loopback for multicast so packets sent on this interface loop back to any socket
+    // joined on the same group.
+    unsigned char loop = 1;
+    if (::setsockopt(tx_fd_,
+                     IPPROTO_IP,
+                     IP_MULTICAST_LOOP,
+                     &loop,
+                     sizeof(loop)) < 0)
+    {
+        return false;
+    }
 
-  return true;
+    // Tell the kernel to use this specific interface for multicast egress.
+    if (::setsockopt(tx_fd_,
+                     IPPROTO_IP,
+                     IP_MULTICAST_IF,
+                     &iface_be,
+                     sizeof(iface_be)) < 0)
+    {
+        return false;
+    }
+
+    return true;
 }
 
+// send(): send a UDP packet (unicast or multicast) on the TX socket. Returns true
+// if the full payload was sent successfully.
 bool NativeUdpSocket::send(Payload payload, const ipv4::Endpoint dest) {
     if (tx_fd_ < 0) {
         return false;
     }
 
+    // Build the destination sockaddr_in using dest.address() and dest.port().
     sockaddr_in dst_addr{};
     std::memset(&dst_addr, 0, sizeof(dst_addr));
     dst_addr.sin_family      = AF_INET;
     dst_addr.sin_addr.s_addr = htonl(dest.address().ToUint32());
     dst_addr.sin_port        = htons(dest.port());
 
+    // sendto() on tx_fd_. If the return doesn’t match payload.size(), treat as failure.
     ssize_t sent = ::sendto(tx_fd_,
                              payload.data(),
                              payload.size(),
@@ -179,31 +187,35 @@ bool NativeUdpSocket::send(Payload payload, const ipv4::Endpoint dest) {
     return (sent == static_cast<ssize_t>(payload.size()));
 }
 
+// receive(): nonblocking attempt to read from either rx_multicast_fd_ or tx_fd_.
+// Uses select() with zero timeout to poll both. Returns the first available packet,
+// preferring multicast (rx_multicast_fd_) over unicast (tx_fd_). Empty Payload if none.
 Payload NativeUdpSocket::receive(ipv4::Endpoint *const peer) {
     if (!is_open()) {
         return {};
     }
 
-    // Build fd_set for select
+    // Prepare the fd_set for select: watch rx_multicast_fd_ and tx_fd_.
     fd_set read_fds;
     FD_ZERO(&read_fds);
     FD_SET(rx_multicast_fd_, &read_fds);
     FD_SET(tx_fd_, &read_fds);
 
+    // The maximum file descriptor plus one for select().
     int max_fd = std::max(rx_multicast_fd_, tx_fd_);
-    timeval timeout{0, 0};  // zero timeout => non‐blocking
+    timeval timeout{0, 0};  // zero timeout => nonblocking
 
     int ready = ::select(max_fd + 1, &read_fds, nullptr, nullptr, &timeout);
     if (ready < 0) {
-        // Real error
+        // Real error occurred in select(); return empty.
         return {};
     }
     if (ready == 0) {
-        // No data on either socket
+        // No socket is ready; return empty immediately.
         return {};
     }
 
-    // Prefer RX if both have data
+    // Determine which descriptor has data. Prefer RX (multicast/unicast via INADDR_ANY)
     int which_fd = -1;
     if (FD_ISSET(rx_multicast_fd_, &read_fds)) {
         which_fd = rx_multicast_fd_;
@@ -212,14 +224,17 @@ Payload NativeUdpSocket::receive(ipv4::Endpoint *const peer) {
     }
 
     if (which_fd < 0) {
+        // Unexpected: no FD was set even though ready > 0. Return empty.
         return {};
     }
 
+    // Prepare a buffer for the worst-case UDP payload (65507 bytes).
     constexpr std::size_t kMaxDatagram = 65507;
     uint8_t tmpBuf[kMaxDatagram];
     sockaddr_in addr{};
     socklen_t addrlen = sizeof(addr);
 
+    // Perform recvfrom() on the chosen FD.
     ssize_t n = ::recvfrom(which_fd,
                            tmpBuf,
                            sizeof(tmpBuf),
@@ -227,24 +242,26 @@ Payload NativeUdpSocket::receive(ipv4::Endpoint *const peer) {
                            reinterpret_cast<sockaddr*>(&addr),
                            &addrlen);
     if (n < 0) {
+        // If it would block, simply return empty. Otherwise, real error.
         if (errno == EAGAIN || errno == EWOULDBLOCK) {
-            // Would block ⇒ no data
             return {};
         }
-        // Real error
         return {};
     }
 
+    // Copy the received data into a Payload of exactly the right size.
     size_t len = static_cast<size_t>(n);
     Payload p(len);
     std::memcpy(p.data(), tmpBuf, len);
 
+    // Populate the peer endpoint (host-order address and port).
     peer->set_address(Address{ ntohl(addr.sin_addr.s_addr) });
     peer->set_port(static_cast<uint16_t>(ntohs(addr.sin_port)));
 
     return p;
 }
 
+// close(): close both TX and RX sockets if they are open, and set FDs to -1.
 void NativeUdpSocket::close() {
     if (tx_fd_ >= 0) {
         ::close(tx_fd_);
@@ -256,39 +273,48 @@ void NativeUdpSocket::close() {
     }
 }
 
+// join_multicast_group(): instruct the RX socket to join a specific multicast group
+// on the interface that was bound to TX. Returns true if setsockopt succeeds.
 bool NativeUdpSocket::join_multicast_group(const ftl::ipv4::Address &group) {
-  if (rx_multicast_fd_ < 0) { return false; }
+    if (rx_multicast_fd_ < 0) {
+        return false;
+    }
 
-  ip_mreq mreq{};
-  mreq.imr_multiaddr.s_addr = htonl(group.ToUint32());
+    ip_mreq mreq{};
+    // Multicast address in network byte order
+    mreq.imr_multiaddr.s_addr = htonl(group.ToUint32());
 
-  uint32_t iface_be = htonl(interface_.address().ToUint32());
-  mreq.imr_interface.s_addr = iface_be;
+    // Interface must match the one used for TX, so loopback or whatever was bound.
+    uint32_t iface_be = htonl(interface_.address().ToUint32());
+    mreq.imr_interface.s_addr = iface_be;
 
-  return (::setsockopt(rx_multicast_fd_,
-                       IPPROTO_IP,
-                       IP_ADD_MEMBERSHIP,
-                       &mreq,
-                       sizeof(mreq)) == 0);
+    // IP_ADD_MEMBERSHIP tells the kernel to deliver that group’s packets for RX.
+    return (::setsockopt(rx_multicast_fd_,
+                         IPPROTO_IP,
+                         IP_ADD_MEMBERSHIP,
+                         &mreq,
+                         sizeof(mreq)) == 0);
 }
 
+// leave_multicast_group(): drop the RX socket’s membership in a multicast group
+// on the same interface. Must use the identical interface address used in join.
 bool NativeUdpSocket::leave_multicast_group(const ftl::ipv4::Address &group) {
-  if (rx_multicast_fd_ < 0) {
-      return false;
-  }
+    if (rx_multicast_fd_ < 0) {
+        return false;
+    }
 
-  ip_mreq mreq{};
-  mreq.imr_multiaddr.s_addr = htonl(group.ToUint32());
+    ip_mreq mreq{};
+    mreq.imr_multiaddr.s_addr = htonl(group.ToUint32());
 
-  // Must drop on the *same* interface we joined on:
-  uint32_t iface_be = htonl(interface_.address().ToUint32());
-  mreq.imr_interface.s_addr = iface_be;
+    // Must drop on the same interface used in join.
+    uint32_t iface_be = htonl(interface_.address().ToUint32());
+    mreq.imr_interface.s_addr = iface_be;
 
-  return (::setsockopt(rx_multicast_fd_,
-                       IPPROTO_IP,
-                       IP_DROP_MEMBERSHIP,
-                       &mreq,
-                       sizeof(mreq)) == 0);
+    return (::setsockopt(rx_multicast_fd_,
+                         IPPROTO_IP,
+                         IP_DROP_MEMBERSHIP,
+                         &mreq,
+                         sizeof(mreq)) == 0);
 }
 
 }  // namespace ftl::ipv4::udp

--- a/firmware/native/native_udp_socket.cpp
+++ b/firmware/native/native_udp_socket.cpp
@@ -1,0 +1,160 @@
+// native_udp_socket.cpp
+#include "ftl/native_udp_socket.hpp"
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <cstring>
+
+namespace ftl::ipv4::udp {
+
+NativeUdpSocket::NativeUdpSocket() = default;
+
+NativeUdpSocket::~NativeUdpSocket() {
+  close();
+}
+
+bool NativeUdpSocket::open(std::size_t receive_queue_len) {
+  if (fd_ >= 0) {
+    return false;  // already open
+  }
+  fd_ = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  if (fd_ < 0) {
+    return false;
+  }
+
+  // allow immediate rebinding of the same address/port
+  int opt = 1;
+  ::setsockopt(fd_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+  // UDP receive queue length is in *datagrams*, but SO_RCVBUF is in *bytes*.
+  // To hold receive_queue_len datagrams of up to kMaxDatagram bytes each:
+  constexpr int kMaxDatagram = 65507;  // Maximum safe UDP payload
+  int buf_bytes = static_cast<int>(receive_queue_len) * kMaxDatagram;
+  ::setsockopt(fd_, SOL_SOCKET, SO_RCVBUF, &buf_bytes, sizeof(buf_bytes));
+
+  return true;
+}
+
+bool NativeUdpSocket::is_open() const noexcept {
+  return fd_ >= 0;
+}
+
+bool NativeUdpSocket::bind(uint16_t port) {
+  if (!is_open()) {
+    return false;
+  }
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = INADDR_ANY;
+  addr.sin_port = htons(port);
+  if (::bind(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+    return false;
+  }
+  return true;
+}
+
+bool NativeUdpSocket::send(Payload payload, const ipv4::Endpoint dest) {
+  if (!is_open()) {
+    return false;
+  }
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = dest.address().ToUint32();
+  addr.sin_port = htons(dest.port());
+  auto sent = ::sendto(fd_,
+                       payload.data(),
+                       payload.size(),
+                       0,
+                       reinterpret_cast<sockaddr*>(&addr),
+                       sizeof(addr));
+  return sent == static_cast<ssize_t>(payload.size());
+}
+
+Payload NativeUdpSocket::receive(ipv4::Endpoint *const peer) {
+  if (!is_open()) {
+    return Payload(0);
+  }
+
+  // 1) Peek the next datagram’s full length
+  sockaddr_in addr{};
+  socklen_t addrlen = sizeof(addr);
+
+  // A 1-byte buffer just to satisfy recvmsg; MSG_TRUNC makes the return
+  // value the real length of the whole datagram, regardless of iov_len.
+  uint8_t  tmp;
+  iovec    iov{ &tmp, 1 };
+  msghdr   msg{};
+  msg.msg_name    = &addr;
+  msg.msg_namelen = addrlen;
+  msg.msg_iov     = &iov;
+  msg.msg_iovlen  = 1;
+
+  ssize_t peek_len = ::recvmsg(fd_, &msg, MSG_PEEK | MSG_TRUNC);
+  if (peek_len < 0) {
+    return Payload(0);
+  }
+
+  size_t packet_len = static_cast<size_t>(peek_len);
+  // Guard against absurd sizes
+  constexpr size_t kMaxDatagram = 65507;
+  if (packet_len > kMaxDatagram) {
+    packet_len = kMaxDatagram;
+  }
+
+  // 2) Allocate exactly the right size
+  Payload p(packet_len);
+
+  // 3) Now actually receive it
+  auto n = ::recvfrom(
+    fd_,
+    p.data(),
+    packet_len,
+    0,
+    reinterpret_cast<sockaddr*>(&addr),
+    &addrlen
+  );
+  if (n < 0 || static_cast<size_t>(n) != packet_len) {
+    return Payload(0);
+  }
+
+  // 4) Fill in peer address and port
+  char addr_str[INET_ADDRSTRLEN];
+  inet_ntop(AF_INET, &addr.sin_addr, addr_str, sizeof(addr_str));
+  peer->set_address(addr_str);
+  peer->set_port(ntohs(addr.sin_port));
+
+  return p;
+}
+
+void NativeUdpSocket::close() {
+  if (fd_ >= 0) {
+    ::close(fd_);
+    fd_ = -1;
+  }
+}
+
+bool NativeUdpSocket::join_multicast_group(const ftl::ipv4::Address &group) {
+  if (!is_open()) {
+    return false;
+  }
+  ip_mreq mreq{};
+  mreq.imr_multiaddr.s_addr = group.ToUint32();
+  mreq.imr_interface.s_addr = INADDR_ANY;
+  return (::setsockopt(fd_, IPPROTO_IP, IP_ADD_MEMBERSHIP,
+                      &mreq, sizeof(mreq)) == 0);
+}
+
+bool NativeUdpSocket::leave_multicast_group(const ftl::ipv4::Address &group) {
+  if (!is_open()) {
+    return false;
+  }
+  ip_mreq mreq{};
+  mreq.imr_multiaddr.s_addr = group.ToUint32();
+  mreq.imr_interface.s_addr = INADDR_ANY;
+  return (::setsockopt(fd_, IPPROTO_IP, IP_DROP_MEMBERSHIP,
+                      &mreq, sizeof(mreq)) == 0);
+}
+
+}  // namespace ftl::ipv4::udp

--- a/test/native/CMakeLists.txt
+++ b/test/native/CMakeLists.txt
@@ -7,6 +7,7 @@ add_platform_test(ut-ftl
   ut_buffer_bump_pool.cpp
   ut_bump_allocator.cpp
   ut_bump_pool.cpp
+  ut_byte_order.cpp
   ut_singleton.cpp
   ut_mutex.cpp
   ut_thread.cpp

--- a/test/native/CMakeLists.txt
+++ b/test/native/CMakeLists.txt
@@ -14,11 +14,11 @@ add_platform_test(ut-ftl
 )
 target_link_libraries(ut-ftl ftl ftl-native)
 
-# Network test
-add_platform_test(ut-network
-  ut_udp_socket.cpp
-)
-target_link_libraries(ut-network ftl ftl-native)
+# # Network test
+# add_platform_test(ut-network
+#   ut_udp_socket.cpp
+# )
+# target_link_libraries(ut-network ftl ftl-native)
 
 # Manual tests
 add_executable(hello-world hello_world.cpp)

--- a/test/native/CMakeLists.txt
+++ b/test/native/CMakeLists.txt
@@ -11,6 +11,7 @@ add_platform_test(ut-ftl
   ut_mutex.cpp
   ut_thread.cpp
   ut_unique_bump_pool.cpp
+  ut_udp_socket.cpp
 )
 target_link_libraries(ut-ftl ftl ftl-native)
 

--- a/test/native/CMakeLists.txt
+++ b/test/native/CMakeLists.txt
@@ -11,9 +11,14 @@ add_platform_test(ut-ftl
   ut_mutex.cpp
   ut_thread.cpp
   ut_unique_bump_pool.cpp
-  ut_udp_socket.cpp
 )
 target_link_libraries(ut-ftl ftl ftl-native)
+
+# Network test
+add_platform_test(ut-network
+  ut_udp_socket.cpp
+)
+target_link_libraries(ut-network ftl ftl-native)
 
 # Manual tests
 add_executable(hello-world hello_world.cpp)

--- a/test/native/CMakeLists.txt
+++ b/test/native/CMakeLists.txt
@@ -18,3 +18,7 @@ target_link_libraries(ut-ftl ftl ftl-native)
 # Manual tests
 add_executable(hello-world hello_world.cpp)
 platformify(hello-world)
+
+add_executable(hello-udp hello_udp.cpp)
+platformify(hello-udp)
+target_link_libraries(hello-udp ftl ftl-native)

--- a/test/native/CMakeLists.txt
+++ b/test/native/CMakeLists.txt
@@ -14,11 +14,11 @@ add_platform_test(ut-ftl
 )
 target_link_libraries(ut-ftl ftl ftl-native)
 
-# # Network test
-# add_platform_test(ut-network
-#   ut_udp_socket.cpp
-# )
-# target_link_libraries(ut-network ftl ftl-native)
+# Network test
+add_platform_test(ut-network
+  ut_udp_socket.cpp
+)
+target_link_libraries(ut-network ftl ftl-native)
 
 # Manual tests
 add_executable(hello-world hello_world.cpp)

--- a/test/native/CMakeLists.txt
+++ b/test/native/CMakeLists.txt
@@ -27,3 +27,7 @@ platformify(hello-world)
 add_executable(hello-udp hello_udp.cpp)
 platformify(hello-udp)
 target_link_libraries(hello-udp ftl ftl-native)
+
+add_executable(hello-udp2 hello_udp2.cpp)
+platformify(hello-udp2)
+target_link_libraries(hello-udp2 ftl ftl-native)

--- a/test/native/hello_udp.cpp
+++ b/test/native/hello_udp.cpp
@@ -53,8 +53,16 @@ int main() {
         std::memcpy(p_send.data(), msg, len);
 
         // 2) Send it
-        if (!sender.send(std::move(p_send), dst)) {
-            std::cerr << "[send] error\n";
+        bool ok = sender.send(std::move(p_send), dst);
+        if (!ok) {
+            std::cerr 
+              << "[send] error, return=false, errno=" << errno 
+              << " (" << std::strerror(errno) << ")\n";
+        } else {
+            std::cout 
+              << "[send] sent " << len 
+              << " bytes → " << dst.address().ToString().c_str()
+              << ":" << dst.port() << "\n";
         }
 
         // 3) Receive it back

--- a/test/native/hello_udp.cpp
+++ b/test/native/hello_udp.cpp
@@ -17,7 +17,7 @@ int main() {
     using namespace ftl::ipv4;
     using namespace ftl::ipv4::udp;
 
-    constexpr uint16_t kReceiverPort    = 54321;
+    constexpr uint16_t kReceiverPort    = 9382U;
     const Address      kLocalAddress{"127.0.0.1"};
     // We will use 239.0.0.42 as our multicast “test” group:
     const Address      kMulticastGroup{239, 0, 0, 42};

--- a/test/native/hello_udp.cpp
+++ b/test/native/hello_udp.cpp
@@ -56,8 +56,10 @@ int main() {
     }
 
     Endpoint multiDst{ kMulticastGroup, kReceiverPort };
+    Endpoint uniDst{ kLocalAddress,  kReceiverPort };
 
-    std::cout << "Starting send/receive loop (127.0.0.1 → 239.0.0.42:" << kReceiverPort << ")\n";
+    std::cout << "Starting send/receive loop (127.0.0.1 → {unicast,multicast} on port " 
+              << kReceiverPort << ")\n";
 
     while (true) {
         // --- Send a multicast packet “Hello multicast” ---
@@ -78,20 +80,39 @@ int main() {
             }
         }
 
-        // Give the kernel a moment to emit and loop back the packet
+        // --- Send a unicast packet “Hello unicast” ---
+        {
+            const char *msg = "Hello unicast";
+            size_t      len = std::strlen(msg);
+            Payload     p_send(len);
+            std::memcpy(p_send.data(), msg, len);
+
+            bool ok = sender->send(std::move(p_send), uniDst);
+            if (!ok) {
+                std::cerr << "[send] unicast error, errno=" << errno
+                          << " (" << std::strerror(errno) << ")\n";
+            } else {
+                std::cout << "[send] unicast: “" << msg 
+                          << "” → " << uniDst.address().ToString().c_str()
+                          << ":" << uniDst.port() << "\n";
+            }
+        }
+
+        // Give the kernel a moment to emit and loop back the packets
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-        // --- Attempt to receive any pending packets ---
+        // --- Attempt to receive any pending packets (both multicast and unicast) ---
         {
             Endpoint peer{};
-            Payload  p_recv = receiver->receive(&peer);
-            if (p_recv) {
+            while (true) {
+                Payload  p_recv = receiver->receive(&peer);
+                if (!p_recv) {
+                    break;  // no more data right now
+                }
                 std::string received{ reinterpret_cast<char*>(p_recv.data()), p_recv.size() };
                 std::cout << "[recv] " 
                           << peer.address().ToString().c_str() << ":" << peer.port()
                           << " → “" << received << "”\n";
-            } else {
-                // No data available right now
             }
         }
 

--- a/test/native/hello_udp.cpp
+++ b/test/native/hello_udp.cpp
@@ -17,7 +17,7 @@ int main() {
     using namespace ftl::ipv4;
     using namespace ftl::ipv4::udp;
 
-    constexpr uint16_t kReceiverPort = 54321;
+    constexpr uint16_t kReceiverPort    = 54321;
     const Address      kLocalAddress{"127.0.0.1"};
     // We will use 239.0.0.42 as our multicast “test” group:
     const Address      kMulticastGroup{239, 0, 0, 42};
@@ -27,94 +27,47 @@ int main() {
 
     ftl::DataFrame::initialize(kAllocator);
 
-    // Create a sender‐socket and a receiver‐socket, bound to the “lo” interface:
+    // Create a sender‐socket bound to the “lo” interface:
     SocketPtr sender = lo.CreateUdpSocket();
-    SocketPtr receiver = lo.CreateUdpSocket();
 
     if (!sender->open(4)) {
         std::cerr << "Failed to open sender socket\n";
         return 1;
     }
-    if (!receiver->open(4)) {
-        std::cerr << "Failed to open receiver socket\n";
+
+    // ← ADD THIS: Bind to loopback (port = 0).  This runs all of
+    // the steps (bind to 127.0.0.1:0, setsockopt(IP_MULTICAST_TTL), setsockopt(IP_MULTICAST_IF), …)
+    if (!sender->bind(0)) {
+        std::cerr << "Failed to bind sender to loopback\n";
         return 1;
     }
 
-    // Bind the receiver to 0.0.0.0:kReceiverPort on the “lo” interface,
-    // then join the multicast group 239.0.0.42:
-    if (!receiver->bind(kReceiverPort)) {
-        std::cerr << "Failed to bind receiver to port " << kReceiverPort << "\n";
-        return 1;
-    }
-    if (!receiver->join_multicast_group(kMulticastGroup)) {
-        std::cerr << "Failed to join multicast group " << kMulticastGroup.ToString().c_str() << "\n";
-        return 1;
-    }
+    // Pre‐construct the multicast endpoint: 239.0.0.42:54321
+    Endpoint multiDst{ kMulticastGroup, kReceiverPort };
 
-    // Pre‐construct two endpoints: unicast→127.0.0.1:kReceiverPort, and multicast→239.0.0.42:kReceiverPort
-    Endpoint unicastDst{ kLocalAddress,   kReceiverPort };
-    Endpoint multiDst{  kMulticastGroup, kReceiverPort };
-
-    std::cout << "Starting send/receive loop on 127.0.0.1:" << kReceiverPort
-              << " (joined multicast " << kMulticastGroup.ToString().c_str() << ")\n";
+    std::cout << "Starting send‐only loop (127.0.0.1 → 239.0.0.42:"
+              << kReceiverPort << ")\n";
 
     while (true) {
-        // --- First: send a unicast packet “Hello unicast” ---
-        {
-            const char *msg_unicast = "Hello unicast";
-            size_t      len_u = std::strlen(msg_unicast);
-            Payload     p_send_u(len_u);
-            std::memcpy(p_send_u.data(), msg_unicast, len_u);
+        const char *msg_multicast = "Hello multicast";
+        size_t      len_m         = std::strlen(msg_multicast);
+        Payload     p_send_m(len_m);
+        std::memcpy(p_send_m.data(), msg_multicast, len_m);
 
-            bool ok = sender->send(std::move(p_send_u), unicastDst);
-            if (!ok) {
-                std::cerr << "[send] unicast error, errno=" << errno
-                          << " (" << std::strerror(errno) << ")\n";
-            } else {
-                std::cout << "[send] unicast: “" << msg_unicast 
-                          << "” → " << unicastDst.address().ToString().c_str()
-                          << ":" << unicastDst.port() << "\n";
-            }
+        bool ok = sender->send(std::move(p_send_m), multiDst);
+        if (!ok) {
+            std::cerr << "[send] multicast error, errno=" << errno
+                      << " (" << std::strerror(errno) << ")\n";
+        } else {
+            std::cout << "[send] multicast: “" << msg_multicast 
+                      << "” → " << multiDst.address().ToString().c_str()
+                      << ":" << multiDst.port() << "\n";
         }
 
-        // --- Then: send a multicast packet “Hello multicast” ---
-        {
-            const char *msg_multicast = "Hello multicast";
-            size_t      len_m = std::strlen(msg_multicast);
-            Payload     p_send_m(len_m);
-            std::memcpy(p_send_m.data(), msg_multicast, len_m);
-
-            bool ok = sender->send(std::move(p_send_m), multiDst);
-            if (!ok) {
-                std::cerr << "[send] multicast error, errno=" << errno
-                          << " (" << std::strerror(errno) << ")\n";
-            } else {
-                std::cout << "[send] multicast: “" << msg_multicast 
-                          << "” → " << multiDst.address().ToString().c_str()
-                          << ":" << multiDst.port() << "\n";
-            }
-        }
-
-        // Give the kernel a moment to loop back the packets:
+        // Give the kernel a moment to emit and loop back the packet
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-        // Attempt to read *all* pending packets (unicast + multicast) until none remain.
-        // Because we opened the socket non‐blocking, receive() will return empty
-        // once the queue is drained.
-        while (true) {
-            Endpoint peer{};
-            Payload  p_recv = receiver->receive(&peer);
-            if (!p_recv) {
-                break; // no more packets in the queue right now
-            }
-            std::string received{ reinterpret_cast<char*>(p_recv.data()), p_recv.size() };
-            std::cout << "[recv] " 
-                      << peer.address().ToString().c_str() 
-                      << ":" << peer.port()
-                      << " → “" << received << "”\n";
-        }
-
-        // Wait a little before sending the next pair:
+        // Wait a bit before sending again
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 

--- a/test/native/hello_udp.cpp
+++ b/test/native/hello_udp.cpp
@@ -67,7 +67,7 @@ int main() {
             const char *msg = "Hello multicast";
             size_t      len = std::strlen(msg);
             Payload     p_send(len);
-            std::memcpy(p_send.data(), msg, len);
+            std::memcpy(p_send.front(), msg, len);
 
             bool ok = sender->send(std::move(p_send), multiDst);
             if (!ok) {
@@ -85,7 +85,7 @@ int main() {
             const char *msg = "Hello unicast";
             size_t      len = std::strlen(msg);
             Payload     p_send(len);
-            std::memcpy(p_send.data(), msg, len);
+            std::memcpy(p_send.front(), msg, len);
 
             bool ok = sender->send(std::move(p_send), uniDst);
             if (!ok) {
@@ -109,7 +109,7 @@ int main() {
                 if (!p_recv) {
                     break;  // no more data right now
                 }
-                std::string received{ reinterpret_cast<char*>(p_recv.data()), p_recv.size() };
+                std::string received{ reinterpret_cast<char*>(p_recv.front()), p_recv.size() };
                 std::cout << "[recv] " 
                           << peer.address().ToString().c_str() << ":" << peer.port()
                           << " → “" << received << "”\n";

--- a/test/native/hello_udp.cpp
+++ b/test/native/hello_udp.cpp
@@ -17,10 +17,9 @@ int main() {
     using namespace ftl::ipv4;
     using namespace ftl::ipv4::udp;
 
-    constexpr uint16_t kSenderPort = 5555;
-    constexpr uint16_t kReceiverPort    = 9382U;
+    constexpr uint16_t kSenderPort   = 5555;
+    constexpr uint16_t kReceiverPort = 9382U;
     const Address      kLocalAddress{"127.0.0.1"};
-    // We will use 239.0.0.42 as our multicast “test” group:
     const Address      kMulticastGroup{239, 0, 0, 42};
 
     // “Loopback” interface just for IPv4 on 127.0.0.1/24
@@ -28,43 +27,73 @@ int main() {
 
     ftl::DataFrame::initialize(kAllocator);
 
-    // Create a sender‐socket bound to the “lo” interface:
+    // Create and configure the sender socket:
     SocketPtr sender = lo.CreateUdpSocket();
-
     if (!sender->open(4)) {
         std::cerr << "Failed to open sender socket\n";
         return 1;
     }
-
     if (!sender->bind(kSenderPort)) {
         std::cerr << "Failed to bind sender to loopback\n";
         return 1;
     }
 
-    // Pre‐construct the multicast endpoint: 239.0.0.42:54321
+    // Create and configure the receiver socket:
+    SocketPtr receiver = lo.CreateUdpSocket();
+    if (!receiver->open(4)) {
+        std::cerr << "Failed to open receiver socket\n";
+        return 1;
+    }
+    // Bind the receiver to port kReceiverPort on loopback (INADDR_ANY in our implementation will use loopback)
+    if (!receiver->bind(kReceiverPort)) {
+        std::cerr << "Failed to bind receiver to port " << kReceiverPort << "\n";
+        return 1;
+    }
+    // Join the multicast group on loopback:
+    if (!receiver->join_multicast_group(kMulticastGroup)) {
+        std::cerr << "Failed to join multicast group " << kMulticastGroup.ToString().c_str() << "\n";
+        return 1;
+    }
+
     Endpoint multiDst{ kMulticastGroup, kReceiverPort };
 
-    std::cout << "Starting send‐only loop (127.0.0.1 → 239.0.0.42:"
-              << kReceiverPort << ")\n";
+    std::cout << "Starting send/receive loop (127.0.0.1 → 239.0.0.42:" << kReceiverPort << ")\n";
 
     while (true) {
-        const char *msg_multicast = "Hello multicast";
-        size_t      len_m         = std::strlen(msg_multicast);
-        Payload     p_send_m(len_m);
-        std::memcpy(p_send_m.data(), msg_multicast, len_m);
+        // --- Send a multicast packet “Hello multicast” ---
+        {
+            const char *msg = "Hello multicast";
+            size_t      len = std::strlen(msg);
+            Payload     p_send(len);
+            std::memcpy(p_send.data(), msg, len);
 
-        bool ok = sender->send(std::move(p_send_m), multiDst);
-        if (!ok) {
-            std::cerr << "[send] multicast error, errno=" << errno
-                      << " (" << std::strerror(errno) << ")\n";
-        } else {
-            std::cout << "[send] multicast: “" << msg_multicast 
-                      << "” → " << multiDst.address().ToString().c_str()
-                      << ":" << multiDst.port() << "\n";
+            bool ok = sender->send(std::move(p_send), multiDst);
+            if (!ok) {
+                std::cerr << "[send] multicast error, errno=" << errno
+                          << " (" << std::strerror(errno) << ")\n";
+            } else {
+                std::cout << "[send] multicast: “" << msg 
+                          << "” → " << multiDst.address().ToString().c_str()
+                          << ":" << multiDst.port() << "\n";
+            }
         }
 
         // Give the kernel a moment to emit and loop back the packet
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        // --- Attempt to receive any pending packets ---
+        {
+            Endpoint peer{};
+            Payload  p_recv = receiver->receive(&peer);
+            if (p_recv) {
+                std::string received{ reinterpret_cast<char*>(p_recv.data()), p_recv.size() };
+                std::cout << "[recv] " 
+                          << peer.address().ToString().c_str() << ":" << peer.port()
+                          << " → “" << received << "”\n";
+            } else {
+                // No data available right now
+            }
+        }
 
         // Wait a bit before sending again
         std::this_thread::sleep_for(std::chrono::milliseconds(500));

--- a/test/native/hello_udp.cpp
+++ b/test/native/hello_udp.cpp
@@ -9,80 +9,114 @@
 #include "ftl/ipv4/endpoint.hpp"
 #include "ftl/ipv4/udp/payload.hpp"
 
-
 static constexpr size_t POOL_MEMORY_SIZE = 16 * 1024;
 uint8_t kBumpBuffer[POOL_MEMORY_SIZE];
 ftl::BumpAllocator kAllocator{kBumpBuffer, POOL_MEMORY_SIZE};
 
 int main() {
-  using namespace ftl::ipv4;
-  using namespace ftl::ipv4::udp;
+    using namespace ftl::ipv4;
+    using namespace ftl::ipv4::udp;
 
-  constexpr uint16_t kReceiverPort = 54321;
-  const Address      kLocalAddress{"127.0.0.1"};
+    constexpr uint16_t kReceiverPort = 54321;
+    const Address      kLocalAddress{"127.0.0.1"};
+    // We will use 239.0.0.42 as our multicast “test” group:
+    const Address      kMulticastGroup{239, 0, 0, 42};
 
-  ftl::ethernet::NativeEthernetInterface lo{Address{"127.0.0.1"}, Mask{"255.255.255.0"}};
+    // “Loopback” interface just for IPv4 on 127.0.0.1/24
+    ftl::ethernet::NativeEthernetInterface lo{ Address{"127.0.0.1"}, Mask{"255.255.255.0"} };
 
-  ftl::DataFrame::initialize(kAllocator);
+    ftl::DataFrame::initialize(kAllocator);
 
-  // Create sender and receiver
-  ftl::ipv4::udp::SocketPtr sender = lo.CreateUdpSocket();
-  ftl::ipv4::udp::SocketPtr receiver = lo.CreateUdpSocket();
+    // Create a sender‐socket and a receiver‐socket, bound to the “lo” interface:
+    SocketPtr sender = lo.CreateUdpSocket();
+    SocketPtr receiver = lo.CreateUdpSocket();
 
-  if (!sender->open(4)) {
-      std::cerr << "Failed to open sender socket\n";
-      return 1;
-  }
-  if (!receiver->open(4)) {
-      std::cerr << "Failed to open receiver socket\n";
-      return 1;
-  }
+    if (!sender->open(4)) {
+        std::cerr << "Failed to open sender socket\n";
+        return 1;
+    }
+    if (!receiver->open(4)) {
+        std::cerr << "Failed to open receiver socket\n";
+        return 1;
+    }
 
-  // Bind receiver to PORT on loopback
-  if (!receiver->bind(kReceiverPort)) {
-      std::cerr << "Failed to bind receiver to port " << kReceiverPort << "\n";
-      return 1;
-  }
+    // Bind the receiver to 0.0.0.0:kReceiverPort on the “lo” interface,
+    // then join the multicast group 239.0.0.42:
+    if (!receiver->bind(kReceiverPort)) {
+        std::cerr << "Failed to bind receiver to port " << kReceiverPort << "\n";
+        return 1;
+    }
+    if (!receiver->join_multicast_group(kMulticastGroup)) {
+        std::cerr << "Failed to join multicast group " << kMulticastGroup.ToString().c_str() << "\n";
+        return 1;
+    }
 
-  Endpoint dst{kLocalAddress, kReceiverPort};
+    // Pre‐construct two endpoints: unicast→127.0.0.1:kReceiverPort, and multicast→239.0.0.42:kReceiverPort
+    Endpoint unicastDst{ kLocalAddress,   kReceiverPort };
+    Endpoint multiDst{  kMulticastGroup, kReceiverPort };
 
-  std::cout << "Starting send/receive loop on 127.0.0.1:" << kReceiverPort << "\n";
+    std::cout << "Starting send/receive loop on 127.0.0.1:" << kReceiverPort
+              << " (joined multicast " << kMulticastGroup.ToString().c_str() << ")\n";
 
-  while (true) {
-      // 1) Prepare the message
-      const char *msg = "hello_udp";
-      size_t      len = std::strlen(msg);
-      Payload     p_send(len);
-      std::memcpy(p_send.data(), msg, len);
+    while (true) {
+        // --- First: send a unicast packet “Hello unicast” ---
+        {
+            const char *msg_unicast = "Hello unicast";
+            size_t      len_u = std::strlen(msg_unicast);
+            Payload     p_send_u(len_u);
+            std::memcpy(p_send_u.data(), msg_unicast, len_u);
 
-      // 2) Send it
-      bool ok = sender->send(std::move(p_send), dst);
-      if (!ok) {
-          std::cerr 
-            << "[send] error, return=false, errno=" << errno 
-            << " (" << std::strerror(errno) << ")\n";
-      } else {
-          std::cout 
-            << "[send] sent " << len 
-            << " bytes → " << dst.address().ToString().c_str()
-            << ":" << dst.port() << "\n";
-      }
+            bool ok = sender->send(std::move(p_send_u), unicastDst);
+            if (!ok) {
+                std::cerr << "[send] unicast error, errno=" << errno
+                          << " (" << std::strerror(errno) << ")\n";
+            } else {
+                std::cout << "[send] unicast: “" << msg_unicast 
+                          << "” → " << unicastDst.address().ToString().c_str()
+                          << ":" << unicastDst.port() << "\n";
+            }
+        }
 
-      // 3) Receive it back
-      Endpoint peer;
-      Payload  p_recv = receiver->receive(&peer);
-      if (p_recv) {
-          std::string received{reinterpret_cast<char*>(p_recv.data()), p_recv.size()};
-          std::cout << "[recv] " 
-                    << peer.address().ToString().c_str() << ":" << peer.port()
-                    << " → " << received << "\n";
-      } else {
-          std::cout << "[recv] no data\n";
-      }
+        // --- Then: send a multicast packet “Hello multicast” ---
+        {
+            const char *msg_multicast = "Hello multicast";
+            size_t      len_m = std::strlen(msg_multicast);
+            Payload     p_send_m(len_m);
+            std::memcpy(p_send_m.data(), msg_multicast, len_m);
 
-      // 4) Wait 100 ms before next iteration
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  }
+            bool ok = sender->send(std::move(p_send_m), multiDst);
+            if (!ok) {
+                std::cerr << "[send] multicast error, errno=" << errno
+                          << " (" << std::strerror(errno) << ")\n";
+            } else {
+                std::cout << "[send] multicast: “" << msg_multicast 
+                          << "” → " << multiDst.address().ToString().c_str()
+                          << ":" << multiDst.port() << "\n";
+            }
+        }
 
-  return 0;
+        // Give the kernel a moment to loop back the packets:
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        // Attempt to read *all* pending packets (unicast + multicast) until none remain.
+        // Because we opened the socket non‐blocking, receive() will return empty
+        // once the queue is drained.
+        while (true) {
+            Endpoint peer{};
+            Payload  p_recv = receiver->receive(&peer);
+            if (!p_recv) {
+                break; // no more packets in the queue right now
+            }
+            std::string received{ reinterpret_cast<char*>(p_recv.data()), p_recv.size() };
+            std::cout << "[recv] " 
+                      << peer.address().ToString().c_str() 
+                      << ":" << peer.port()
+                      << " → “" << received << "”\n";
+        }
+
+        // Wait a little before sending the next pair:
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+
+    return 0;
 }

--- a/test/native/hello_udp.cpp
+++ b/test/native/hello_udp.cpp
@@ -1,0 +1,77 @@
+#include <iostream>
+#include <thread>
+#include <chrono>
+#include <cstring>
+
+#include "ftl/bump_allocator.hpp"
+#include "ftl/native_udp_socket.hpp"
+#include "ftl/ipv4/endpoint.hpp"
+#include "ftl/ipv4/udp/payload.hpp"
+
+
+static constexpr size_t POOL_MEMORY_SIZE = 16 * 1024;
+uint8_t kBumpBuffer[POOL_MEMORY_SIZE];
+ftl::BumpAllocator kAllocator{kBumpBuffer, POOL_MEMORY_SIZE};
+
+int main() {
+    using namespace ftl::ipv4;
+    using namespace ftl::ipv4::udp;
+
+    ftl::DataFrame::initialize(kAllocator);
+
+    constexpr uint16_t PORT = 54321;
+    const Address       LOCAL_ADDR{"127.0.0.1"};
+
+    // Create sender and receiver
+    NativeUdpSocket sender;
+    NativeUdpSocket receiver;
+
+    if (!sender.open(4)) {
+        std::cerr << "Failed to open sender socket\n";
+        return 1;
+    }
+    if (!receiver.open(4)) {
+        std::cerr << "Failed to open receiver socket\n";
+        return 1;
+    }
+
+    // Bind receiver to PORT on loopback
+    if (!receiver.bind(PORT)) {
+        std::cerr << "Failed to bind receiver to port " << PORT << "\n";
+        return 1;
+    }
+
+    Endpoint dst{LOCAL_ADDR, PORT};
+
+    std::cout << "Starting send/receive loop on 127.0.0.1:" << PORT << "\n";
+
+    while (true) {
+        // 1) Prepare the message
+        const char *msg = "hello_udp";
+        size_t      len = std::strlen(msg);
+        Payload     p_send(len);
+        std::memcpy(p_send.data(), msg, len);
+
+        // 2) Send it
+        if (!sender.send(std::move(p_send), dst)) {
+            std::cerr << "[send] error\n";
+        }
+
+        // 3) Receive it back
+        Endpoint peer;
+        Payload  p_recv = receiver.receive(&peer);
+        if (p_recv) {
+            std::string received{reinterpret_cast<char*>(p_recv.data()), p_recv.size()};
+            std::cout << "[recv] " 
+                      << peer.address().ToString().c_str() << ":" << peer.port()
+                      << " → " << received << "\n";
+        } else {
+            std::cout << "[recv] no data\n";
+        }
+
+        // 4) Wait 100 ms before next iteration
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    return 0;
+}

--- a/test/native/hello_udp.cpp
+++ b/test/native/hello_udp.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <cstring>
 
+#include "ftl/native_ethernet_interface.hpp"
 #include "ftl/bump_allocator.hpp"
 #include "ftl/native_udp_socket.hpp"
 #include "ftl/ipv4/endpoint.hpp"
@@ -14,72 +15,74 @@ uint8_t kBumpBuffer[POOL_MEMORY_SIZE];
 ftl::BumpAllocator kAllocator{kBumpBuffer, POOL_MEMORY_SIZE};
 
 int main() {
-    using namespace ftl::ipv4;
-    using namespace ftl::ipv4::udp;
+  using namespace ftl::ipv4;
+  using namespace ftl::ipv4::udp;
 
-    ftl::DataFrame::initialize(kAllocator);
+  constexpr uint16_t kReceiverPort = 54321;
+  const Address      kLocalAddress{"127.0.0.1"};
 
-    constexpr uint16_t PORT = 54321;
-    const Address       LOCAL_ADDR{"127.0.0.1"};
+  ftl::ethernet::NativeEthernetInterface lo{Address{"127.0.0.1"}, Mask{"255.255.255.0"}};
 
-    // Create sender and receiver
-    NativeUdpSocket sender;
-    NativeUdpSocket receiver;
+  ftl::DataFrame::initialize(kAllocator);
 
-    if (!sender.open(4)) {
-        std::cerr << "Failed to open sender socket\n";
-        return 1;
-    }
-    if (!receiver.open(4)) {
-        std::cerr << "Failed to open receiver socket\n";
-        return 1;
-    }
+  // Create sender and receiver
+  ftl::ipv4::udp::SocketPtr sender = lo.CreateUdpSocket();
+  ftl::ipv4::udp::SocketPtr receiver = lo.CreateUdpSocket();
 
-    // Bind receiver to PORT on loopback
-    if (!receiver.bind(PORT)) {
-        std::cerr << "Failed to bind receiver to port " << PORT << "\n";
-        return 1;
-    }
+  if (!sender->open(4)) {
+      std::cerr << "Failed to open sender socket\n";
+      return 1;
+  }
+  if (!receiver->open(4)) {
+      std::cerr << "Failed to open receiver socket\n";
+      return 1;
+  }
 
-    Endpoint dst{LOCAL_ADDR, PORT};
+  // Bind receiver to PORT on loopback
+  if (!receiver->bind(kReceiverPort)) {
+      std::cerr << "Failed to bind receiver to port " << kReceiverPort << "\n";
+      return 1;
+  }
 
-    std::cout << "Starting send/receive loop on 127.0.0.1:" << PORT << "\n";
+  Endpoint dst{kLocalAddress, kReceiverPort};
 
-    while (true) {
-        // 1) Prepare the message
-        const char *msg = "hello_udp";
-        size_t      len = std::strlen(msg);
-        Payload     p_send(len);
-        std::memcpy(p_send.data(), msg, len);
+  std::cout << "Starting send/receive loop on 127.0.0.1:" << kReceiverPort << "\n";
 
-        // 2) Send it
-        bool ok = sender.send(std::move(p_send), dst);
-        if (!ok) {
-            std::cerr 
-              << "[send] error, return=false, errno=" << errno 
-              << " (" << std::strerror(errno) << ")\n";
-        } else {
-            std::cout 
-              << "[send] sent " << len 
-              << " bytes → " << dst.address().ToString().c_str()
-              << ":" << dst.port() << "\n";
-        }
+  while (true) {
+      // 1) Prepare the message
+      const char *msg = "hello_udp";
+      size_t      len = std::strlen(msg);
+      Payload     p_send(len);
+      std::memcpy(p_send.data(), msg, len);
 
-        // 3) Receive it back
-        Endpoint peer;
-        Payload  p_recv = receiver.receive(&peer);
-        if (p_recv) {
-            std::string received{reinterpret_cast<char*>(p_recv.data()), p_recv.size()};
-            std::cout << "[recv] " 
-                      << peer.address().ToString().c_str() << ":" << peer.port()
-                      << " → " << received << "\n";
-        } else {
-            std::cout << "[recv] no data\n";
-        }
+      // 2) Send it
+      bool ok = sender->send(std::move(p_send), dst);
+      if (!ok) {
+          std::cerr 
+            << "[send] error, return=false, errno=" << errno 
+            << " (" << std::strerror(errno) << ")\n";
+      } else {
+          std::cout 
+            << "[send] sent " << len 
+            << " bytes → " << dst.address().ToString().c_str()
+            << ":" << dst.port() << "\n";
+      }
 
-        // 4) Wait 100 ms before next iteration
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
+      // 3) Receive it back
+      Endpoint peer;
+      Payload  p_recv = receiver->receive(&peer);
+      if (p_recv) {
+          std::string received{reinterpret_cast<char*>(p_recv.data()), p_recv.size()};
+          std::cout << "[recv] " 
+                    << peer.address().ToString().c_str() << ":" << peer.port()
+                    << " → " << received << "\n";
+      } else {
+          std::cout << "[recv] no data\n";
+      }
 
-    return 0;
+      // 4) Wait 100 ms before next iteration
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  return 0;
 }

--- a/test/native/hello_udp.cpp
+++ b/test/native/hello_udp.cpp
@@ -17,6 +17,7 @@ int main() {
     using namespace ftl::ipv4;
     using namespace ftl::ipv4::udp;
 
+    constexpr uint16_t kSenderPort = 5555;
     constexpr uint16_t kReceiverPort    = 9382U;
     const Address      kLocalAddress{"127.0.0.1"};
     // We will use 239.0.0.42 as our multicast “test” group:
@@ -35,9 +36,7 @@ int main() {
         return 1;
     }
 
-    // ← ADD THIS: Bind to loopback (port = 0).  This runs all of
-    // the steps (bind to 127.0.0.1:0, setsockopt(IP_MULTICAST_TTL), setsockopt(IP_MULTICAST_IF), …)
-    if (!sender->bind(0)) {
+    if (!sender->bind(kSenderPort)) {
         std::cerr << "Failed to bind sender to loopback\n";
         return 1;
     }

--- a/test/native/hello_udp2.cpp
+++ b/test/native/hello_udp2.cpp
@@ -1,0 +1,182 @@
+// hello_multicast_send.cpp
+//
+// Minimal C++17 example for sending a “Hello multicast” message on the loopback interface
+// so you can verify it in Wireshark (capture on “lo”).
+//
+// Build with:
+//   g++ -std=c++17 -Wall -Wextra hello_multicast_send.cpp -o hello_multicast_send
+
+#include <arpa/inet.h>   // inet_pton, htonl, htons
+#include <errno.h>
+#include <fcntl.h>       // fcntl, O_NONBLOCK
+#include <stdint.h>      // uint32_t, uint16_t, uint8_t
+#include <stdio.h>       // printf, fprintf, strerror
+#include <string.h>      // memset, strlen
+#include <sys/socket.h>  // socket, setsockopt, bind, sendto
+#include <unistd.h>      // close
+
+#define OVERRIDE_TTL 16
+
+struct UDPTxHandle { int fd; };
+
+/// Initialize a UDP transmit socket on `local_iface_address_nbo`.
+/// Steps:
+///   1) socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+///   2) bind to <local_iface_address>:0
+///   3) fcntl(fd, F_SETFL, O_NONBLOCK)
+///   4) setsockopt(IPPROTO_IP, IP_MULTICAST_TTL, OVERRIDE_TTL)
+///   5) setsockopt(IPPROTO_IP, IP_MULTICAST_IF, local_iface_address)
+///
+/// Returns 0 on success or -errno on failure.
+int16_t udpTxInit(UDPTxHandle* self, uint32_t local_iface_address_nbo)
+{
+    if (self == nullptr || local_iface_address_nbo == 0) {
+        return -EINVAL;
+    }
+
+    self->fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (self->fd < 0) {
+        return -(int16_t)errno;
+    }
+
+    bool ok = true;
+
+    // 1) Bind to <local_iface_address>:0
+    sockaddr_in bind_addr;
+    memset(&bind_addr, 0, sizeof(bind_addr));
+    bind_addr.sin_family      = AF_INET;
+    bind_addr.sin_addr.s_addr = htonl(local_iface_address_nbo);
+    bind_addr.sin_port        = htons(0);
+    ok = ok && (::bind(self->fd,
+                       reinterpret_cast<sockaddr*>(&bind_addr),
+                       sizeof(bind_addr)) == 0);
+
+    // 2) Non‐blocking
+    ok = ok && (fcntl(self->fd, F_SETFL, O_NONBLOCK) == 0);
+
+    // 3) Multicast TTL
+    int ttl = OVERRIDE_TTL;
+    ok = ok && (setsockopt(self->fd,
+                           IPPROTO_IP,
+                           IP_MULTICAST_TTL,
+                           &ttl,
+                           sizeof(ttl)) == 0);
+
+    // 4) Egress interface for multicast
+    uint32_t iface_be = htonl(local_iface_address_nbo);
+    ok = ok && (setsockopt(self->fd,
+                           IPPROTO_IP,
+                           IP_MULTICAST_IF,
+                           &iface_be,
+                           sizeof(iface_be)) == 0);
+
+    if (!ok) {
+        int e = errno;
+        close(self->fd);
+        self->fd = -1;
+        return (int16_t)-e;
+    }
+    return 0;
+}
+
+/// Send one UDP datagram. Returns +1 on success, 0 if would block, or -errno otherwise.
+int16_t udpTxSend(UDPTxHandle* self,
+                  uint32_t     remote_address_nbo,
+                  uint16_t     remote_port,
+                  uint8_t      dscp,
+                  const void*  payload,
+                  size_t       payload_size)
+{
+    if (self == nullptr || self->fd < 0
+        || remote_address_nbo == 0 || remote_port == 0
+        || payload == nullptr || dscp > 63U)
+    {
+        return -EINVAL;
+    }
+
+    // Set DSCP in TOS field
+    int tos = (dscp << 2);
+    setsockopt(self->fd, IPPROTO_IP, IP_TOS, &tos, sizeof(tos));
+
+    sockaddr_in to_addr;
+    memset(&to_addr, 0, sizeof(to_addr));
+    to_addr.sin_family      = AF_INET;
+    to_addr.sin_addr.s_addr = htonl(remote_address_nbo);
+    to_addr.sin_port        = htons(remote_port);
+
+    ssize_t sent = sendto(self->fd,
+                          payload,
+                          payload_size,
+                          MSG_DONTWAIT,
+                          reinterpret_cast<sockaddr*>(&to_addr),
+                          sizeof(to_addr));
+    if (sent < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            return 0;
+        }
+        return (int16_t)-errno;
+    }
+    return (sent == (ssize_t)payload_size) ? +1 : -EIO;
+}
+
+void udpTxClose(UDPTxHandle* self)
+{
+    if (self && self->fd >= 0) {
+        close(self->fd);
+        self->fd = -1;
+    }
+}
+
+int main()
+{
+    const char *iface_str = "127.0.0.1";
+    const char *mcast_str = "239.0.0.42";
+    const uint16_t MCAST_PORT = 12345;
+
+    // 1) Convert “127.0.0.1” → in_addr, then to host-order uint32_t
+    in_addr tmp_addr;
+    if (inet_pton(AF_INET, iface_str, &tmp_addr) != 1) {
+        fprintf(stderr, "inet_pton(%s) failed: %s\n", iface_str, strerror(errno));
+        return 1;
+    }
+    uint32_t local_iface_be = ntohl(tmp_addr.s_addr);
+
+    // 2) Convert “239.0.0.42” → host-order uint32_t
+    if (inet_pton(AF_INET, mcast_str, &tmp_addr) != 1) {
+        fprintf(stderr, "inet_pton(%s) failed: %s\n", mcast_str, strerror(errno));
+        return 1;
+    }
+    uint32_t mcast_be = ntohl(tmp_addr.s_addr);
+
+    // 3) Init TX
+    UDPTxHandle tx{ .fd = -1 };
+    if (udpTxInit(&tx, local_iface_be) < 0) {
+        fprintf(stderr, "udpTxInit failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    // 4) Send “Hello multicast”
+
+    while (1) {
+        const char *message = "Hello multicast";
+        int16_t send_res = udpTxSend(&tx,
+                                    mcast_be,
+                                    MCAST_PORT,
+                                    /*dscp=*/0,
+                                    message,
+                                    strlen(message));
+        if (send_res < 0) {
+            fprintf(stderr, "udpTxSend failed: %s\n", strerror(-send_res));
+            udpTxClose(&tx);
+            return 1;
+        }
+        printf("Sent: “%s” → %s:%u\n", message, mcast_str, (unsigned)MCAST_PORT);
+
+        // 5) Give kernel a moment to emit the packet
+        ::usleep(100 * 1000);
+    }
+
+    // 6) Clean up and exit
+    udpTxClose(&tx);
+    return 0;
+}

--- a/test/native/hello_udp2.cpp
+++ b/test/native/hello_udp2.cpp
@@ -51,24 +51,24 @@ int16_t udpTxInit(UDPTxHandle* self, uint32_t local_iface_address_nbo)
                        reinterpret_cast<sockaddr*>(&bind_addr),
                        sizeof(bind_addr)) == 0);
 
-    // 2) Non‐blocking
-    ok = ok && (fcntl(self->fd, F_SETFL, O_NONBLOCK) == 0);
+    // // 2) Non‐blocking
+    // ok = ok && (fcntl(self->fd, F_SETFL, O_NONBLOCK) == 0);
 
-    // 3) Multicast TTL
-    int ttl = OVERRIDE_TTL;
-    ok = ok && (setsockopt(self->fd,
-                           IPPROTO_IP,
-                           IP_MULTICAST_TTL,
-                           &ttl,
-                           sizeof(ttl)) == 0);
+    // // 3) Multicast TTL
+    // int ttl = OVERRIDE_TTL;
+    // ok = ok && (setsockopt(self->fd,
+    //                        IPPROTO_IP,
+    //                        IP_MULTICAST_TTL,
+    //                        &ttl,
+    //                        sizeof(ttl)) == 0);
 
-    // 4) Egress interface for multicast
-    uint32_t iface_be = htonl(local_iface_address_nbo);
-    ok = ok && (setsockopt(self->fd,
-                           IPPROTO_IP,
-                           IP_MULTICAST_IF,
-                           &iface_be,
-                           sizeof(iface_be)) == 0);
+    // // 4) Egress interface for multicast
+    // uint32_t iface_be = htonl(local_iface_address_nbo);
+    // ok = ok && (setsockopt(self->fd,
+    //                        IPPROTO_IP,
+    //                        IP_MULTICAST_IF,
+    //                        &iface_be,
+    //                        sizeof(iface_be)) == 0);
 
     if (!ok) {
         int e = errno;

--- a/test/native/ut_buffer_bump_pool.cpp
+++ b/test/native/ut_buffer_bump_pool.cpp
@@ -79,12 +79,19 @@ TEST_F(BufferBumpPoolTest, AcquireMinimalHeadAdvance) {
 
         // payload always rounded up to kAlign
         size_t bufBytes = ((sz + kAlign - 1) / kAlign) * kAlign;
-        // metadata = next‐pointer + Buffer handle
-        size_t metadata = sizeof(void*) + sizeof(ftl::Buffer);
-        // total bytes requested
-        size_t total = metadata + bufBytes;
-        // expected bump = round_up(total, kAlign)
-        size_t expectedAdvance = ((total + kAlign - 1) / kAlign) * kAlign;
+        // The Node contains next pointer + Buffer handle. Let's estimate size:
+        // sizeof(void*) + sizeof(Buffer) + potential padding
+        struct NodeProxy {
+            void* next;
+            ftl::Buffer buf;
+        };
+        size_t nodeSize = sizeof(NodeProxy);
+        
+        // Simulate the implementation's padding calculation
+        uintptr_t base = reinterpret_cast<uintptr_t>(headBefore) + nodeSize;
+        size_t pad = (kAlign - (base % kAlign)) % kAlign;
+        size_t totalBytes = nodeSize + pad + bufBytes;
+        size_t expectedAdvance = totalBytes;
         // actual observed bump
         size_t actualAdvance = static_cast<size_t>(headAfter - headBefore);
 

--- a/test/native/ut_byte_order.cpp
+++ b/test/native/ut_byte_order.cpp
@@ -1,0 +1,158 @@
+#include "gtest/gtest.h"
+#include "ftl/byte_order.hpp"
+#include <cstring>
+
+class ByteOrderTest : public ::testing::Test {
+protected:
+    uint8_t buffer[8];
+
+    void SetUp() override {
+        std::memset(buffer, 0, sizeof(buffer));
+    }
+};
+
+// Test uint16_t little-endian operations
+TEST_F(ByteOrderTest, WriteReadU16LE) {
+    uint16_t original = 0x1234;
+    
+    ftl::WriteU16LE(buffer, original);
+    
+    // Verify byte order in buffer
+    EXPECT_EQ(buffer[0], 0x34);
+    EXPECT_EQ(buffer[1], 0x12);
+    
+    // Verify round-trip
+    uint16_t result = ftl::ReadU16LE(buffer);
+    EXPECT_EQ(result, original);
+}
+
+// Test uint16_t big-endian operations
+TEST_F(ByteOrderTest, WriteReadU16BE) {
+    uint16_t original = 0x1234;
+    
+    ftl::WriteU16BE(buffer, original);
+    
+    // Verify byte order in buffer
+    EXPECT_EQ(buffer[0], 0x12);
+    EXPECT_EQ(buffer[1], 0x34);
+    
+    // Verify round-trip
+    uint16_t result = ftl::ReadU16BE(buffer);
+    EXPECT_EQ(result, original);
+}
+
+// Test uint32_t little-endian operations
+TEST_F(ByteOrderTest, WriteReadU32LE) {
+    uint32_t original = 0x12345678;
+    
+    ftl::WriteU32LE(buffer, original);
+    
+    // Verify byte order in buffer
+    EXPECT_EQ(buffer[0], 0x78);
+    EXPECT_EQ(buffer[1], 0x56);
+    EXPECT_EQ(buffer[2], 0x34);
+    EXPECT_EQ(buffer[3], 0x12);
+    
+    // Verify round-trip
+    uint32_t result = ftl::ReadU32LE(buffer);
+    EXPECT_EQ(result, original);
+}
+
+// Test uint32_t big-endian operations
+TEST_F(ByteOrderTest, WriteReadU32BE) {
+    uint32_t original = 0x12345678;
+    
+    ftl::WriteU32BE(buffer, original);
+    
+    // Verify byte order in buffer
+    EXPECT_EQ(buffer[0], 0x12);
+    EXPECT_EQ(buffer[1], 0x34);
+    EXPECT_EQ(buffer[2], 0x56);
+    EXPECT_EQ(buffer[3], 0x78);
+    
+    // Verify round-trip
+    uint32_t result = ftl::ReadU32BE(buffer);
+    EXPECT_EQ(result, original);
+}
+
+// Test uint64_t little-endian operations
+TEST_F(ByteOrderTest, WriteReadU64LE) {
+    uint64_t original = 0x123456789ABCDEF0;
+    
+    ftl::WriteU64LE(buffer, original);
+    
+    // Verify byte order in buffer
+    EXPECT_EQ(buffer[0], 0xF0);
+    EXPECT_EQ(buffer[1], 0xDE);
+    EXPECT_EQ(buffer[2], 0xBC);
+    EXPECT_EQ(buffer[3], 0x9A);
+    EXPECT_EQ(buffer[4], 0x78);
+    EXPECT_EQ(buffer[5], 0x56);
+    EXPECT_EQ(buffer[6], 0x34);
+    EXPECT_EQ(buffer[7], 0x12);
+    
+    // Verify round-trip
+    uint64_t result = ftl::ReadU64LE(buffer);
+    EXPECT_EQ(result, original);
+}
+
+// Test uint64_t big-endian operations
+TEST_F(ByteOrderTest, WriteReadU64BE) {
+    uint64_t original = 0x123456789ABCDEF0;
+    
+    ftl::WriteU64BE(buffer, original);
+    
+    // Verify byte order in buffer
+    EXPECT_EQ(buffer[0], 0x12);
+    EXPECT_EQ(buffer[1], 0x34);
+    EXPECT_EQ(buffer[2], 0x56);
+    EXPECT_EQ(buffer[3], 0x78);
+    EXPECT_EQ(buffer[4], 0x9A);
+    EXPECT_EQ(buffer[5], 0xBC);
+    EXPECT_EQ(buffer[6], 0xDE);
+    EXPECT_EQ(buffer[7], 0xF0);
+    
+    // Verify round-trip
+    uint64_t result = ftl::ReadU64BE(buffer);
+    EXPECT_EQ(result, original);
+}
+
+// Test edge cases
+TEST_F(ByteOrderTest, EdgeCases) {
+    // Test zero values
+    ftl::WriteU16LE(buffer, 0);
+    EXPECT_EQ(ftl::ReadU16LE(buffer), 0);
+    
+    ftl::WriteU32BE(buffer, 0);
+    EXPECT_EQ(ftl::ReadU32BE(buffer), 0);
+    
+    ftl::WriteU64LE(buffer, 0);
+    EXPECT_EQ(ftl::ReadU64LE(buffer), 0);
+    
+    // Test maximum values
+    ftl::WriteU16LE(buffer, 0xFFFF);
+    EXPECT_EQ(ftl::ReadU16LE(buffer), 0xFFFF);
+    
+    ftl::WriteU32BE(buffer, 0xFFFFFFFF);
+    EXPECT_EQ(ftl::ReadU32BE(buffer), 0xFFFFFFFF);
+    
+    ftl::WriteU64LE(buffer, 0xFFFFFFFFFFFFFFFF);
+    EXPECT_EQ(ftl::ReadU64LE(buffer), 0xFFFFFFFFFFFFFFFF);
+}
+
+// Test that LE and BE operations produce different byte patterns for the same value
+TEST_F(ByteOrderTest, EndiannessDifference) {
+    uint32_t value = 0x12345678;
+    uint8_t le_buffer[4];
+    uint8_t be_buffer[4];
+    
+    ftl::WriteU32LE(le_buffer, value);
+    ftl::WriteU32BE(be_buffer, value);
+    
+    // Buffers should contain different byte patterns
+    EXPECT_NE(std::memcmp(le_buffer, be_buffer, 4), 0);
+    
+    // But both should read back to the original value
+    EXPECT_EQ(ftl::ReadU32LE(le_buffer), value);
+    EXPECT_EQ(ftl::ReadU32BE(be_buffer), value);
+}

--- a/test/native/ut_udp_socket.cpp
+++ b/test/native/ut_udp_socket.cpp
@@ -1,101 +1,116 @@
-// Filename: native_udp_socket_test.cpp
+// native_udp_socket_test.cpp
 
 #include <gtest/gtest.h>
-#include "ftl/native_udp_socket.hpp"
-#include "ftl/ipv4/endpoint.hpp"
-#include "ftl/ipv4/udp/payload.hpp"
-
-#include <cstring>
 #include <thread>
 #include <chrono>
+#include <cstring>
 
+#include "ftl/native_ethernet_interface.hpp"
+#include "ftl/ipv4/endpoint.hpp"
+#include "ftl/ipv4/mask.hpp"
+#include "ftl/ipv4/udp/socket.hpp"
+#include "ftl/ipv4/udp/payload.hpp"
+#include "ftl/bump_allocator.hpp"
+
+using ftl::ethernet::NativeEthernetInterface;
 using ftl::ipv4::Address;
+using ftl::ipv4::Mask;
 using ftl::ipv4::Endpoint;
-using ftl::ipv4::udp::NativeUdpSocket;
+using ftl::ipv4::udp::SocketPtr;
 using ftl::ipv4::udp::Payload;
 
 class NativeUdpSocketTest : public ::testing::Test {
-protected:
-  static constexpr size_t POOL_MEMORY_SIZE = 16 * 1024;
-  uint8_t*           buffer_;
-  ftl::BumpAllocator* allocator_;
-  NativeUdpSocket sender_;
-  NativeUdpSocket receiver_;
-  
-  
-  void SetUp() override {
-    buffer_    = new uint8_t[POOL_MEMORY_SIZE];
-    allocator_ = new ftl::BumpAllocator(buffer_, POOL_MEMORY_SIZE);
-    ftl::DataFrame::initialize(*allocator_);
-    ASSERT_TRUE(sender_.open(4));
-    ASSERT_TRUE(receiver_.open(4));
-  }
+  protected:
+    static constexpr size_t POOL_MEMORY_SIZE = 16 * 1024;
+    uint8_t*              buffer_   = nullptr;
+    ftl::BumpAllocator*   allocator_= nullptr;
+    NativeEthernetInterface* lo_     = nullptr;
+    SocketPtr             sender_;
+    SocketPtr             receiver_;
 
-  void TearDown() override {
-    sender_.close();
-    receiver_.close();
-    delete allocator_;
-    delete[] buffer_;
-  }
+    void SetUp() override {
+        // bump allocator + DataFrame
+        buffer_    = new uint8_t[POOL_MEMORY_SIZE];
+        allocator_ = new ftl::BumpAllocator(buffer_, POOL_MEMORY_SIZE);
+        ftl::DataFrame::initialize(*allocator_);
+
+        // construct the interface here
+        lo_ = new NativeEthernetInterface(
+            Address{"127.0.0.1"},
+            Mask   {"255.255.255.0"}
+        );
+
+        // create sockets
+        sender_   = std::move(lo_->CreateUdpSocket());
+        receiver_ = std::move(lo_->CreateUdpSocket());
+
+        ASSERT_TRUE(sender_->open(4));
+        ASSERT_TRUE(receiver_->open(4));
+    }
+
+    void TearDown() override {
+        sender_->close();
+        receiver_->close();
+        delete lo_;
+        delete allocator_;
+        delete[] buffer_;
+    }
 };
+  
 
 // Test unicast send/receive on loopback
 TEST_F(NativeUdpSocketTest, UnicastSendReceive) {
-    constexpr uint16_t kSenderPort = 5555;
+    constexpr uint16_t kSenderPort   = 5555;
     constexpr uint16_t kReceiverPort = 5556;
-    ASSERT_TRUE(sender_.bind(kSenderPort));
-    ASSERT_TRUE(receiver_.bind(kReceiverPort));
 
-    // Prepare payload (Payload(size) auto-sets .size())
-    const char *msg = "hello_unicast";
-    (void)msg;
+    ASSERT_TRUE(sender_->bind(kSenderPort));
+    ASSERT_TRUE(receiver_->bind(kReceiverPort));
+
+    const char* msg = "hello_unicast";
     Payload p_send(std::strlen(msg));
     std::memcpy(p_send.data(), msg, std::strlen(msg));
 
-    // Send to loopback 127.0.0.1
-    Endpoint dst(Address{"127.0.0.1"}, kReceiverPort);
-    ASSERT_TRUE(sender_.send(std::move(p_send), dst));
+    Endpoint dst{ Address{"127.0.0.1"}, kReceiverPort };
+    ASSERT_TRUE(sender_->send(std::move(p_send), dst));
+
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    // Receive
     Endpoint peer{};
-    Payload p_recv = receiver_.receive(&peer);
+    Payload  p_recv = receiver_->receive(&peer);
     ASSERT_TRUE(p_recv);
-    std::string received(reinterpret_cast<char*>(p_recv.data()), p_recv.size());
+    std::string received{ reinterpret_cast<char*>(p_recv.data()), p_recv.size() };
     EXPECT_EQ(received, msg);
-
-    // Peer addr must match exactly an Address
     EXPECT_EQ(peer.address(), Address{"127.0.0.1"});
-    EXPECT_EQ(peer.port(), kSenderPort);
+    EXPECT_EQ(peer.port(),    kSenderPort);
 }
 
 // Test multicast send/receive on loopback
 TEST_F(NativeUdpSocketTest, MulticastSendReceive) {
-  constexpr uint16_t kSenderPort = 5555;
-  constexpr uint16_t kReceiverPort = 5556;
-  // 239.0.0.42
-  Address group{ 239, 0, 0, 42 };
+    constexpr uint16_t kSenderPort   = 5555;
+    constexpr uint16_t kReceiverPort = 5556;
+    Address group{ 239, 0, 0, 42 };  // 239.0.0.42
 
-  ASSERT_TRUE(sender_.bind(kSenderPort));
-  ASSERT_TRUE(receiver_.bind(kReceiverPort));
-  ASSERT_TRUE(receiver_.join_multicast_group(group));
+    ASSERT_TRUE(sender_->bind(kSenderPort));
+    ASSERT_TRUE(receiver_->bind(kReceiverPort));
+    ASSERT_TRUE(receiver_->join_multicast_group(group));
 
-  const char* msg = "hello_multicast";
-  Payload p_send(std::strlen(msg));
-  std::memcpy(p_send.data(), msg, std::strlen(msg));
+    const char* msg = "hello_multicast";
+    Payload p_send(std::strlen(msg));
+    std::memcpy(p_send.data(), msg, std::strlen(msg));
 
-  Endpoint dst{ group, kReceiverPort };
-  ASSERT_TRUE(sender_.send(std::move(p_send), dst));
+    Endpoint dst{ group, kReceiverPort };
+    ASSERT_TRUE(sender_->send(std::move(p_send), dst));
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-  Endpoint peer{};
-  Payload p_recv = receiver_.receive(&peer);
-  ASSERT_TRUE(p_recv);
-  std::string received{ reinterpret_cast<char*>(p_recv.data()), p_recv.size() };
-  EXPECT_EQ(received, msg);
+    Endpoint peer{};
+    Payload  p_recv = receiver_->receive(&peer);
+    ASSERT_TRUE(p_recv);
+    std::string received{ reinterpret_cast<char*>(p_recv.data()), p_recv.size() };
+    EXPECT_EQ(received, msg);
 
-  // Only check the port for multicast
-  EXPECT_EQ(peer.port(), kSenderPort);
-  ASSERT_TRUE(receiver_.leave_multicast_group(group));
+    // For multicast we only reliably check the source port
+    EXPECT_EQ(peer.port(), kSenderPort);
+
+    ASSERT_TRUE(receiver_->leave_multicast_group(group));
 }

--- a/test/native/ut_udp_socket.cpp
+++ b/test/native/ut_udp_socket.cpp
@@ -6,6 +6,8 @@
 #include "ftl/ipv4/udp/payload.hpp"
 
 #include <cstring>
+#include <thread>
+#include <chrono>
 
 using ftl::ipv4::Address;
 using ftl::ipv4::Endpoint;
@@ -39,18 +41,25 @@ protected:
 
 // Test unicast send/receive on loopback
 TEST_F(NativeUdpSocketTest, UnicastSendReceive) {
-    constexpr uint16_t PORT = 54321;
+    constexpr uint16_t PORT = 5555;
     ASSERT_TRUE(receiver_.bind(PORT));
 
-    // Prepare payload (Payload(size) auto-sets .size())
-    const char *msg = "hello_unicast";
-    (void)msg;
-    Payload p_send(std::strlen(msg));
-    std::memcpy(p_send.data(), msg, std::strlen(msg));
+    while (1)
+    {
 
-    // Send to loopback 127.0.0.1
-    Endpoint dst(Address{"127.0.0.1"}, PORT);
-    ASSERT_TRUE(sender_.send(std::move(p_send), dst));
+      // Prepare payload (Payload(size) auto-sets .size())
+      const char *msg = "hello_unicast";
+      (void)msg;
+      Payload p_send(std::strlen(msg));
+      std::memcpy(p_send.data(), msg, std::strlen(msg));
+
+      // Send to loopback 127.0.0.1
+      Endpoint dst(Address{"127.0.0.1"}, PORT);
+      ASSERT_TRUE(sender_.send(std::move(p_send), dst));
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+      std::cout << "loop" << std::endl;
+    }
 
     // Receive
     Endpoint peer{};

--- a/test/native/ut_udp_socket.cpp
+++ b/test/native/ut_udp_socket.cpp
@@ -68,7 +68,7 @@ TEST_F(NativeUdpSocketTest, UnicastSendReceive) {
 
     const char* msg = "hello_unicast";
     Payload p_send(std::strlen(msg));
-    std::memcpy(p_send.data(), msg, std::strlen(msg));
+    std::memcpy(p_send.front(), msg, std::strlen(msg));
 
     Endpoint dst{ Address{"127.0.0.1"}, kReceiverPort };
     ASSERT_TRUE(sender_->send(std::move(p_send), dst));
@@ -78,7 +78,7 @@ TEST_F(NativeUdpSocketTest, UnicastSendReceive) {
     Endpoint peer{};
     Payload  p_recv = receiver_->receive(&peer);
     ASSERT_TRUE(p_recv);
-    std::string received{ reinterpret_cast<char*>(p_recv.data()), p_recv.size() };
+    std::string received{ reinterpret_cast<char*>(p_recv.front()), p_recv.size() };
     EXPECT_EQ(received, msg);
     EXPECT_EQ(peer.address(), Address{"127.0.0.1"});
     EXPECT_EQ(peer.port(),    kSenderPort);
@@ -96,7 +96,7 @@ TEST_F(NativeUdpSocketTest, MulticastSendReceive) {
 
     const char* msg = "hello_multicast";
     Payload p_send(std::strlen(msg));
-    std::memcpy(p_send.data(), msg, std::strlen(msg));
+    std::memcpy(p_send.front(), msg, std::strlen(msg));
 
     Endpoint dst{ group, kReceiverPort };
     ASSERT_TRUE(sender_->send(std::move(p_send), dst));
@@ -106,7 +106,7 @@ TEST_F(NativeUdpSocketTest, MulticastSendReceive) {
     Endpoint peer{};
     Payload  p_recv = receiver_->receive(&peer);
     ASSERT_TRUE(p_recv);
-    std::string received{ reinterpret_cast<char*>(p_recv.data()), p_recv.size() };
+    std::string received{ reinterpret_cast<char*>(p_recv.front()), p_recv.size() };
     EXPECT_EQ(received, msg);
 
     // For multicast we only reliably check the source port

--- a/test/native/ut_udp_socket.cpp
+++ b/test/native/ut_udp_socket.cpp
@@ -69,29 +69,33 @@ TEST_F(NativeUdpSocketTest, UnicastSendReceive) {
     EXPECT_EQ(peer.port(), kSenderPort);
 }
 
-// // Test multicast send/receive on loopback
-// TEST_F(NativeUdpSocketTest, MulticastSendReceive) {
-//     constexpr uint16_t PORT = 12345;
-//     Address group{0xEF00002Au};  // 239.0.0.42
+// Test multicast send/receive on loopback
+TEST_F(NativeUdpSocketTest, MulticastSendReceive) {
+  constexpr uint16_t kSenderPort = 5555;
+  constexpr uint16_t kReceiverPort = 5556;
+  // 239.0.0.42
+  Address group{ 239, 0, 0, 42 };
 
-//     ASSERT_TRUE(receiver_.bind(PORT));
-//     ASSERT_TRUE(receiver_.join_multicast_group(group));
+  ASSERT_TRUE(sender_.bind(kSenderPort));
+  ASSERT_TRUE(receiver_.bind(kReceiverPort));
+  ASSERT_TRUE(receiver_.join_multicast_group(group));
 
-//     const char *msg = "hello_multicast";
-//     Payload p_send(std::strlen(msg));
-//     std::memcpy(p_send.data(), msg, std::strlen(msg));
+  const char* msg = "hello_multicast";
+  Payload p_send(std::strlen(msg));
+  std::memcpy(p_send.data(), msg, std::strlen(msg));
 
-//     Endpoint dst(group, PORT);
-//     ASSERT_TRUE(sender_.send(std::move(p_send), dst));
+  Endpoint dst{ group, kReceiverPort };
+  ASSERT_TRUE(sender_.send(std::move(p_send), dst));
 
-//     Endpoint peer{};
-//     Payload p_recv = receiver_.receive(&peer);
-//     ASSERT_EQ(p_recv.size(), std::strlen(msg));
-//     std::string received(reinterpret_cast<char*>(p_recv.data()), p_recv.size());
-//     EXPECT_EQ(received, msg);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-//     // For multicast we only reliably check the port
-//     EXPECT_EQ(peer.port(), PORT);
+  Endpoint peer{};
+  Payload p_recv = receiver_.receive(&peer);
+  ASSERT_TRUE(p_recv);
+  std::string received{ reinterpret_cast<char*>(p_recv.data()), p_recv.size() };
+  EXPECT_EQ(received, msg);
 
-//     ASSERT_TRUE(receiver_.leave_multicast_group(group));
-// }
+  // Only check the port for multicast
+  EXPECT_EQ(peer.port(), kSenderPort);
+  ASSERT_TRUE(receiver_.leave_multicast_group(group));
+}

--- a/test/native/ut_udp_socket.cpp
+++ b/test/native/ut_udp_socket.cpp
@@ -1,0 +1,92 @@
+// Filename: native_udp_socket_test.cpp
+
+#include <gtest/gtest.h>
+#include "ftl/native_udp_socket.hpp"
+#include "ftl/ipv4/endpoint.hpp"
+#include "ftl/ipv4/udp/payload.hpp"
+
+#include <cstring>
+
+using ftl::ipv4::Address;
+using ftl::ipv4::Endpoint;
+using ftl::ipv4::udp::NativeUdpSocket;
+using ftl::ipv4::udp::Payload;
+
+class NativeUdpSocketTest : public ::testing::Test {
+protected:
+  static constexpr size_t POOL_MEMORY_SIZE = 16 * 1024;
+  uint8_t*           buffer_;
+  ftl::BumpAllocator* allocator_;
+  NativeUdpSocket sender_;
+  NativeUdpSocket receiver_;
+  
+  
+  void SetUp() override {
+    buffer_    = new uint8_t[POOL_MEMORY_SIZE];
+    allocator_ = new ftl::BumpAllocator(buffer_, POOL_MEMORY_SIZE);
+    ftl::DataFrame::initialize(*allocator_);
+    ASSERT_TRUE(sender_.open(4));
+    ASSERT_TRUE(receiver_.open(4));
+  }
+
+  void TearDown() override {
+    sender_.close();
+    receiver_.close();
+    delete allocator_;
+    delete[] buffer_;
+  }
+};
+
+// Test unicast send/receive on loopback
+TEST_F(NativeUdpSocketTest, UnicastSendReceive) {
+    constexpr uint16_t PORT = 54321;
+    ASSERT_TRUE(receiver_.bind(PORT));
+
+    // Prepare payload (Payload(size) auto-sets .size())
+    const char *msg = "hello_unicast";
+    (void)msg;
+    Payload p_send(std::strlen(msg));
+    std::memcpy(p_send.data(), msg, std::strlen(msg));
+
+    // Send to loopback 127.0.0.1
+    Endpoint dst(Address{0x7F000001u}, PORT);
+    ASSERT_TRUE(sender_.send(std::move(p_send), dst));
+
+    // Receive
+    Endpoint peer{};
+    Payload p_recv = receiver_.receive(&peer);
+    // ASSERT_EQ(p_recv.size(), std::strlen(msg));
+    // std::string received(reinterpret_cast<char*>(p_recv.data()), p_recv.size());
+    // EXPECT_EQ(received, msg);
+
+    // // Peer addr must match exactly an Address
+    // EXPECT_EQ(peer.address(), Address{0x7F000001u});
+    // EXPECT_EQ(peer.port(), PORT);
+}
+
+// // Test multicast send/receive on loopback
+// TEST_F(NativeUdpSocketTest, MulticastSendReceive) {
+//     constexpr uint16_t PORT = 12345;
+//     Address group{0xEF00002Au};  // 239.0.0.42
+
+//     ASSERT_TRUE(receiver_.bind(PORT));
+//     ASSERT_TRUE(receiver_.join_multicast_group(group));
+
+//     const char *msg = "hello_multicast";
+//     Payload p_send(std::strlen(msg));
+//     std::memcpy(p_send.data(), msg, std::strlen(msg));
+
+//     Endpoint dst(group, PORT);
+//     ASSERT_TRUE(sender_.send(std::move(p_send), dst));
+
+//     Endpoint peer{};
+//     Payload p_recv = receiver_.receive(&peer);
+//     ASSERT_EQ(p_recv.size(), std::strlen(msg));
+//     std::string received(reinterpret_cast<char*>(p_recv.data()), p_recv.size());
+//     EXPECT_EQ(received, msg);
+
+//     // For multicast we only reliably check the port
+//     EXPECT_EQ(peer.port(), PORT);
+
+//     ASSERT_TRUE(receiver_.leave_multicast_group(group));
+// }

--- a/test/native/ut_udp_socket.cpp
+++ b/test/native/ut_udp_socket.cpp
@@ -49,13 +49,13 @@ TEST_F(NativeUdpSocketTest, UnicastSendReceive) {
     std::memcpy(p_send.data(), msg, std::strlen(msg));
 
     // Send to loopback 127.0.0.1
-    Endpoint dst(Address{0x7F000001u}, PORT);
+    Endpoint dst(Address{"127.0.0.1"}, PORT);
     ASSERT_TRUE(sender_.send(std::move(p_send), dst));
 
     // Receive
     Endpoint peer{};
     Payload p_recv = receiver_.receive(&peer);
-    // ASSERT_EQ(p_recv.size(), std::strlen(msg));
+    ASSERT_TRUE(p_recv);
     // std::string received(reinterpret_cast<char*>(p_recv.data()), p_recv.size());
     // EXPECT_EQ(received, msg);
 

--- a/test/native/ut_udp_socket.cpp
+++ b/test/native/ut_udp_socket.cpp
@@ -41,36 +41,32 @@ protected:
 
 // Test unicast send/receive on loopback
 TEST_F(NativeUdpSocketTest, UnicastSendReceive) {
-    constexpr uint16_t PORT = 5555;
-    ASSERT_TRUE(receiver_.bind(PORT));
+    constexpr uint16_t kSenderPort = 5555;
+    constexpr uint16_t kReceiverPort = 5556;
+    ASSERT_TRUE(sender_.bind(kSenderPort));
+    ASSERT_TRUE(receiver_.bind(kReceiverPort));
 
-    while (1)
-    {
+    // Prepare payload (Payload(size) auto-sets .size())
+    const char *msg = "hello_unicast";
+    (void)msg;
+    Payload p_send(std::strlen(msg));
+    std::memcpy(p_send.data(), msg, std::strlen(msg));
 
-      // Prepare payload (Payload(size) auto-sets .size())
-      const char *msg = "hello_unicast";
-      (void)msg;
-      Payload p_send(std::strlen(msg));
-      std::memcpy(p_send.data(), msg, std::strlen(msg));
-
-      // Send to loopback 127.0.0.1
-      Endpoint dst(Address{"127.0.0.1"}, PORT);
-      ASSERT_TRUE(sender_.send(std::move(p_send), dst));
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-      std::cout << "loop" << std::endl;
-    }
+    // Send to loopback 127.0.0.1
+    Endpoint dst(Address{"127.0.0.1"}, kReceiverPort);
+    ASSERT_TRUE(sender_.send(std::move(p_send), dst));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     // Receive
     Endpoint peer{};
     Payload p_recv = receiver_.receive(&peer);
     ASSERT_TRUE(p_recv);
-    // std::string received(reinterpret_cast<char*>(p_recv.data()), p_recv.size());
-    // EXPECT_EQ(received, msg);
+    std::string received(reinterpret_cast<char*>(p_recv.data()), p_recv.size());
+    EXPECT_EQ(received, msg);
 
-    // // Peer addr must match exactly an Address
-    // EXPECT_EQ(peer.address(), Address{0x7F000001u});
-    // EXPECT_EQ(peer.port(), PORT);
+    // Peer addr must match exactly an Address
+    EXPECT_EQ(peer.address(), Address{"127.0.0.1"});
+    EXPECT_EQ(peer.port(), kSenderPort);
 }
 
 // // Test multicast send/receive on loopback


### PR DESCRIPTION
## Overview

This PR introduces native UDP/multicast socket support, a native Ethernet interface, byte order utilities, and significant improvements to the Forge project’s embedded networking capabilities.

---

## Major Features

- **Native UDP & Multicast Socket Implementation**  
  - C++ implementation supporting both unicast and multicast networking.  
  - Correctly manages socket binding, multicast group membership, and network traffic routing.  
  - Includes detailed code comments explaining kernel/network behavior.

- **Native Ethernet Interface**  
  - Adds `NativeEthernetInterface` for binding sockets to specified IP addresses and subnet masks.

- **Byte Order Utilities**  
  - New utilities for reading and writing 16, 32, and 64-bit integers in little-endian and big-endian formats.

- **Expanded FTL (Forge Template Library) Abstractions**  
  - Improved memory management and polymorphic deleters.  
  - Enhanced UDP payload APIs.

- **Comprehensive Testing**  
  - Unit tests for byte order and UDP socket functionality.  
  - Manual test programs (e.g., `hello_udp.cpp`, `hello_udp2.cpp`) demonstrating unicast/multicast scenarios—compatible with Wireshark packet capture for debugging.

- **Build & Documentation Updates**  
  - CMake updates for new source files and test targets.  
  - New `CLAUDE.md` for developer instructions, architecture, and style guidance.  
  - Updated `README.md` with latest usage instructions.

---

## Impact

- Enables robust cross-platform UDP networking, including multicast, for embedded and native development.
- Improves testability and developer ergonomics.
- Provides a foundation for further protocol and network feature expansion.

---